### PR TITLE
[SBL-21] 공통 응답 객체 및 에러 헨들러 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
+    // validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
     // Swagger
     implementation("org.springdoc:springdoc-openapi:2.3.0")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/controller/DemoController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/controller/DemoController.kt
@@ -1,8 +1,12 @@
 package com.sbl.sulmun2yong.demo.controller
 
 import com.sbl.sulmun2yong.demo.controller.doc.DemoApiDoc
-import com.sbl.sulmun2yong.demo.entity.Demo
+import com.sbl.sulmun2yong.demo.dto.request.DemoCreateRequest
+import com.sbl.sulmun2yong.demo.dto.response.DemoResponse
 import com.sbl.sulmun2yong.demo.service.DemoService
+import com.sbl.sulmun2yong.global.response.ApiResponse
+import com.sbl.sulmun2yong.global.response.SuccessCode
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -16,14 +20,16 @@ class DemoController(private val demoService: DemoService) : DemoApiDoc {
     @GetMapping("/{id}")
     override fun getDemo(
         @PathVariable id: Long,
-    ): Demo {
-        return demoService.getDemo(id)
+    ): ApiResponse<DemoResponse> {
+        val demoResponse = demoService.getDemo(id)
+        return ApiResponse.of(SuccessCode.FIND_DEMO_SUCCESS, demoResponse)
     }
 
     @PostMapping
     override fun createDemo(
-        @RequestBody demo: Demo,
-    ): Long {
-        return demoService.createDemo(demo)
+        @Valid @RequestBody demoCreateRequest: DemoCreateRequest,
+    ): ApiResponse<DemoResponse> {
+        val demoResponse = demoService.createDemo(demoCreateRequest)
+        return ApiResponse.of(SuccessCode.CREATE_DEMO_SUCCESS, demoResponse)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/controller/doc/DemoApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/controller/doc/DemoApiDoc.kt
@@ -1,6 +1,8 @@
 package com.sbl.sulmun2yong.demo.controller.doc
 
-import com.sbl.sulmun2yong.demo.entity.Demo
+import com.sbl.sulmun2yong.demo.dto.request.DemoCreateRequest
+import com.sbl.sulmun2yong.demo.dto.response.DemoResponse
+import com.sbl.sulmun2yong.global.response.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PathVariable
@@ -11,10 +13,10 @@ interface DemoApiDoc {
     @Operation(summary = "Demo 조회")
     fun getDemo(
         @PathVariable id: Long,
-    ): Demo
+    ): ApiResponse<DemoResponse>
 
     @Operation(summary = "Demo 생성")
     fun createDemo(
-        @RequestBody demo: Demo,
-    ): Long
+        @RequestBody demoCreateRequest: DemoCreateRequest,
+    ): ApiResponse<DemoResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/dto/request/DemoCreateRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/dto/request/DemoCreateRequest.kt
@@ -1,0 +1,15 @@
+package com.sbl.sulmun2yong.demo.dto.request
+
+import com.sbl.sulmun2yong.demo.entity.Demo
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class DemoCreateRequest(
+    @field:NotBlank
+    @field:Size(max = 10)
+    val title: String,
+) {
+    fun toEntity(): Demo {
+        return Demo(title = title)
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/dto/response/DemoResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/dto/response/DemoResponse.kt
@@ -1,0 +1,14 @@
+package com.sbl.sulmun2yong.demo.dto.response
+
+import com.sbl.sulmun2yong.demo.entity.Demo
+
+data class DemoResponse private constructor(
+    val id: Long,
+    val title: String,
+) {
+    companion object {
+        fun from(demo: Demo): DemoResponse {
+            return DemoResponse(demo.id, demo.title)
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/entity/Demo.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/entity/Demo.kt
@@ -8,9 +8,10 @@ import jakarta.persistence.Id
 
 @Entity
 class Demo(
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long,
     @Column(nullable = false, length = 100)
     val title: String,
-)
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/exception/DemoNotFoundException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/exception/DemoNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.demo.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class DemoNotFoundException : BusinessException(ErrorCode.DEMO_NOT_FOUND)

--- a/src/main/kotlin/com/sbl/sulmun2yong/demo/service/DemoService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/demo/service/DemoService.kt
@@ -1,16 +1,20 @@
 package com.sbl.sulmun2yong.demo.service
 
-import com.sbl.sulmun2yong.demo.entity.Demo
+import com.sbl.sulmun2yong.demo.dto.request.DemoCreateRequest
+import com.sbl.sulmun2yong.demo.dto.response.DemoResponse
+import com.sbl.sulmun2yong.demo.exception.DemoNotFoundException
 import com.sbl.sulmun2yong.demo.repository.DemoRepository
 import org.springframework.stereotype.Service
 
 @Service
 class DemoService(private val demoRepository: DemoRepository) {
-    fun getDemo(id: Long): Demo {
-        return demoRepository.findById(id).orElseThrow { IllegalArgumentException("해당 데이터가 없습니다.") }
+    fun getDemo(id: Long): DemoResponse {
+        val demo = demoRepository.findById(id).orElseThrow { DemoNotFoundException() }
+        return DemoResponse.from(demo)
     }
 
-    fun createDemo(demo: Demo): Long {
-        return demoRepository.save(demo).id
+    fun createDemo(demoCreateRequest: DemoCreateRequest): DemoResponse {
+        val demo = demoCreateRequest.toEntity()
+        return DemoResponse.from(demoRepository.save(demo))
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/BusinessException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/BusinessException.kt
@@ -1,0 +1,3 @@
+package com.sbl.sulmun2yong.global.error
+
+open class BusinessException(val errorCode: ErrorCode) : RuntimeException(errorCode.message)

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -1,0 +1,12 @@
+package com.sbl.sulmun2yong.global.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(val httpStatus: HttpStatus, val code: String, val message: String) {
+    // Global (GL)
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GL0001", "서버 오류가 발생했습니다."),
+    INPUT_INVALID_VALUE(HttpStatus.BAD_REQUEST, "GL0002", "잘못된 입력입니다."),
+
+    // Demo (DM)
+    DEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "DM0001", "데모를 찾을 수 없습니다."),
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorResponse.kt
@@ -1,0 +1,54 @@
+package com.sbl.sulmun2yong.global.error
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindingResult
+
+class ErrorResponse private constructor(
+    httpStatus: HttpStatus,
+    body: ErrorResponseBody,
+) : ResponseEntity<Any>(body, httpStatus) {
+    companion object {
+        fun of(code: ErrorCode): ErrorResponse {
+            val body =
+                ErrorResponseBody(
+                    code = code.code,
+                    message = code.message,
+                )
+            return ErrorResponse(code.httpStatus, body)
+        }
+
+        fun of(
+            code: ErrorCode,
+            bindingResult: BindingResult,
+        ): ErrorResponse {
+            val fieldErrors =
+                bindingResult.fieldErrors.map { error ->
+                    FieldError(
+                        field = error.field,
+                        value = error.rejectedValue?.toString() ?: "",
+                        reason = error.defaultMessage ?: "",
+                    )
+                }
+            val body =
+                ErrorResponseBody(
+                    code = code.code,
+                    message = code.message,
+                    errors = fieldErrors,
+                )
+            return ErrorResponse(code.httpStatus, body)
+        }
+    }
+
+    data class ErrorResponseBody(
+        val code: String,
+        val message: String,
+        val errors: List<FieldError> = listOf(),
+    )
+
+    data class FieldError(
+        val field: String,
+        val value: String,
+        val reason: String,
+    )
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/GlobalExceptionHandler.kt
@@ -1,0 +1,29 @@
+package com.sbl.sulmun2yong.global.error
+
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @ExceptionHandler(Exception::class)
+    protected fun handleException(e: Exception): ErrorResponse {
+        log.error(e.message, e)
+        return ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR)
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    protected fun handleRuntimeException(e: BusinessException): ErrorResponse {
+        log.warn(e.message, e)
+        return ErrorResponse.of(e.errorCode)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    protected fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ErrorResponse {
+        log.warn(e.message, e)
+        return ErrorResponse.of(ErrorCode.INPUT_INVALID_VALUE, e.bindingResult)
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/response/ApiResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/response/ApiResponse.kt
@@ -20,6 +20,6 @@ class ApiResponse<T> private constructor(
     data class ApiResponseBody<T>(
         val code: String,
         val message: String,
-        val data: T?,
+        val result: T?,
     )
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/response/ApiResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/response/ApiResponse.kt
@@ -1,0 +1,25 @@
+package com.sbl.sulmun2yong.global.response
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+class ApiResponse<T> private constructor(
+    httpStatus: HttpStatus,
+    body: ApiResponseBody<T>,
+) : ResponseEntity<Any>(body, httpStatus) {
+    companion object {
+        fun <T> of(
+            successCode: SuccessCode,
+            data: T,
+        ): ApiResponse<T> {
+            val body = ApiResponseBody(successCode.code, successCode.message, data)
+            return ApiResponse(successCode.httpStatus, body)
+        }
+    }
+
+    data class ApiResponseBody<T>(
+        val code: String,
+        val message: String,
+        val data: T?,
+    )
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/response/SuccessCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/response/SuccessCode.kt
@@ -1,0 +1,9 @@
+package com.sbl.sulmun2yong.global.response
+
+import org.springframework.http.HttpStatus
+
+enum class SuccessCode(val code: String, val message: String, val httpStatus: HttpStatus) {
+    // Demo (DM)
+    CREATE_DEMO_SUCCESS("DM0001", "데모 정보 생성을 성공했습니다.", HttpStatus.CREATED),
+    FIND_DEMO_SUCCESS("DM0002", "데모 정보 조회를 성공했습니다.", HttpStatus.OK),
+}


### PR DESCRIPTION
## 📢 설명
- API의 응답 형식을 아래와 같이 정의
    
    ```json
    {
      "code": "응답의 코드, AA0001 과 같은 형식",
      "message": "응답의 메시지",
      "data": {
        // 필요한 데이터
      }
    }
    ```

- 예외 발생 시 응답 형식을 아래와 같이 정의
    
    ```json
    {
      "code": "에러 코드, AA0001 과 같은 형식",
      "message": "에러의 메시지",
      "errors": [
        {
          "field": "요청 필드 명",
          "value": "요청 값",
          "reason": "예외 발생 이유"
        }
      ]
    }
    ```

- 예외 핸들링 관련
    - `GlobalExceptionHandler`에서 발생한 예외들을 핸들링
    - 발생한 예외가 BusinessException 클래스를 상속했다면 해당 예외의 code와 message를 포함하여 응답으로 반환
    - 발생한 예외가 `MethodArgumentNotValidException`(dto validate시 발생하는 예외)면 유효성 검사에 실패한 필드 정보와 이유가 함께 errors 배열에 포함되어 반환

## ✅ 체크 리스트
- [ ] Demo 생성 API(`POST`, `/api/v1/demo`) 호출시 응답이 형태대로 잘 오는지 확인
- [ ] Demo 생성 API(`POST`, `/api/v1/demo`) 호출시 title을 10자 초과로 설정하거나, 공백으로 설정할 경우 예외가 잘 반환되는지 확인
- [ ] Demo 조회 API(`GET`, `/api/v1/demo/{id}`) 호출 시 응답이 형태대로 잘 오는지 확인
- [ ] Demo 조회 API(`GET`, `/api/v1/demo/{id}`) 호출 시 없는 id로 조회 시 예외가 잘 반환되는지 확인
