### PR TITLE
[SBL-63] Jacoco 추가, PR 작성 시 SonarQube 분석 후 Commant 작성하도록 CI 파이프라인 작성

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -22,7 +22,7 @@ jobs:
 
             - name: SonarQube BaseURL 삽입
               run: |
-                  echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
+                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
 
             - name: Gradle 패키지 캐싱
               uses: actions/cache@v2

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -20,6 +20,10 @@ jobs:
                   distribution: 'temurin'
                   java-version: '17'
 
+            - name: SonarQube BaseURL 삽입
+              run: |
+                  echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
+
             - name: Gradle 패키지 캐싱
               uses: actions/cache@v2
               with:
@@ -32,18 +36,6 @@ jobs:
 
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck
-
-            - name: SonarQube BaseURL 삽입
-              run: |
-                echo "sonar.coverage.jacoco.xmlReportPaths=$(pwd)/build/reports/jacoco/test/jacocoTestReport.xml" >> sonar-project.properties
-                echo "sonar.projectKey=${{secrets.SONARQUBE_PROJECT_KEY}}" >> sonar-project.properties
-                echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
-
-            - name: sonar-project.properties 파일 내용 확인
-              run: |
-                  grep "sonar.coverage.jacoco.xmlReportPaths" sonar-project.properties
-                  grep "sonar.projectKey" sonar-project.properties
-                  grep "sonar.core.serverBaseURL" sonar-project.properties
 
             - name: SonarQube 분석 실행 후 PR Commant 작성
               uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -34,7 +34,10 @@ jobs:
               run: ./gradlew ktlintCheck
 
             - name: SonarQube BaseURL 삽입
-              run: echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
+              run: |
+                echo "sonar.coverage.jacoco.xmlReportPaths=$(pwd)/build/reports/jacoco/test/jacocoTestReport.xml" >> sonar-project.properties
+                echo "sonar.projectKey=${{SONARQUBE_PROJECT_KEY}}" >> sonar-project.properties
+                echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
 
             - name: SonarQube 분석 실행 후 PR Commant 작성
               uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -22,7 +22,7 @@ jobs:
 
             - name: SonarQube BaseURL 삽입
               run: |
-                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> ${pwd}/sonar-project.properties
+                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> $(pwd)/sonar-project.properties
 
             - name: Gradle 패키지 캐싱
               uses: actions/cache@v2

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -34,6 +34,15 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-gradle-
 
+            - name: 빌드 출력 확인
+              run: cat build/reports/jacoco/test/jacocoTestReport.xml
+
+            - name: sonar-project.properties 파일 내용 확인
+              run: |
+                  grep "sonar.coverage.jacoco.xmlReportPaths" sonar-project.properties
+                  grep "sonar.projectKey" sonar-project.properties
+                  grep "sonar.core.serverBaseURL" sonar-project.properties
+
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -39,6 +39,12 @@ jobs:
                 echo "sonar.projectKey=${{secrets.SONARQUBE_PROJECT_KEY}}" >> sonar-project.properties
                 echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
 
+            - name: sonar-project.properties 파일 내용 확인
+              run: |
+                  grep "sonar.coverage.jacoco.xmlReportPaths" sonar-project.properties
+                  grep "sonar.projectKey" sonar-project.properties
+                  grep "sonar.core.serverBaseURL" sonar-project.properties
+
             - name: SonarQube 분석 실행 후 PR Commant 작성
               uses: sonarsource/sonarqube-scan-action@master
               env:

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -20,6 +20,9 @@ jobs:
                   distribution: 'temurin'
                   java-version: '17'
 
+            - name: 경로 확인
+              run: ls -a
+
             - name: SonarQube BaseURL 삽입
               run: |
                   echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> $(pwd)/sonar-project.properties
@@ -34,14 +37,14 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-gradle-
 
-            - name: 빌드 출력 확인
-              run: cat $(pwd)/build/reports/jacoco/test/jacocoTestReport.xml
-
             - name: sonar-project.properties 파일 내용 확인
               run: |
                   grep "sonar.projectKey" $(pwd)/sonar-project.properties
-                  grep "sonar.core.serverBaseURL" $(pwd)/sonar-project.properties
-                  grep "sonar.coverage.jacoco.xmlReportPaths" $(pwd)/sonar-project.properties
+                  grep "sonar.host.url" $(pwd)/sonar-project.properties
+                  grep "sonar.junit.reportPaths" $(pwd)/sonar-project.properties
+
+            - name: 빌드 출력 확인
+              run: cat $(pwd)/build/reports/jacoco/test/jacocoTestReport.xml
 
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -20,12 +20,9 @@ jobs:
                   distribution: 'temurin'
                   java-version: '17'
 
-            - name: 경로 확인
-              run: ls -a
-
             - name: SonarQube BaseURL 삽입
               run: |
-                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> $(pwd)/sonar-project.properties
+                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> ${pwd}/sonar-project.properties
 
             - name: Gradle 패키지 캐싱
               uses: actions/cache@v2
@@ -37,14 +34,17 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-gradle-
 
-            - name: sonar-project.properties 파일 내용 확인
-              run: |
-                  grep "sonar.projectKey" $(pwd)/sonar-project.properties
-                  grep "sonar.host.url" $(pwd)/sonar-project.properties
-                  grep "sonar.junit.reportPaths" $(pwd)/sonar-project.properties
+            - name: Gradle 빌드
+              run: ./gradlew build
+
+            - name: 경로 확인
+              run: ls -a
+
+            - name: 경로 확인
+              run: ls ./build/reports
 
             - name: 빌드 출력 확인
-              run: cat $(pwd)/build/reports/jacoco/test/jacocoTestReport.xml
+              run: cat ./build/reports/jacoco/test/jacocoTestReport.xml
 
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -32,3 +32,12 @@ jobs:
 
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck
+
+            - name: SonarQube 프로젝트키 삽입
+              run: echo "sonar.projectKey=${{ secrets.SONARQUBE_PROJECT_KEY }}" >> sonar-project.properties
+
+            - name: SonarQube 분석 실행 후 PR Commant 작성
+              uses: sonarsource/sonarqube-scan-action@master
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+                  SONAR_HOST_URL: ${{ secrets.SONARQUBE_EC2_HOST }}

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -39,9 +39,9 @@ jobs:
 
             - name: sonar-project.properties 파일 내용 확인
               run: |
-                  grep "sonar.coverage.jacoco.xmlReportPaths" $(pwd)/sonar-project.properties
                   grep "sonar.projectKey" $(pwd)/sonar-project.properties
                   grep "sonar.core.serverBaseURL" $(pwd)/sonar-project.properties
+                  grep "sonar.coverage.jacoco.xmlReportPaths" $(pwd)/sonar-project.properties
 
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -36,7 +36,7 @@ jobs:
             - name: SonarQube BaseURL 삽입
               run: |
                 echo "sonar.coverage.jacoco.xmlReportPaths=$(pwd)/build/reports/jacoco/test/jacocoTestReport.xml" >> sonar-project.properties
-                echo "sonar.projectKey=${{SONARQUBE_PROJECT_KEY}}" >> sonar-project.properties
+                echo "sonar.projectKey=${{secrets.SONARQUBE_PROJECT_KEY}}" >> sonar-project.properties
                 echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
 
             - name: SonarQube 분석 실행 후 PR Commant 작성

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -37,15 +37,6 @@ jobs:
             - name: Gradle 빌드
               run: ./gradlew build
 
-            - name: 경로 확인
-              run: ls -a
-
-            - name: 경로 확인
-              run: ls ./build/reports
-
-            - name: 빌드 출력 확인
-              run: cat ./build/reports/jacoco/test/jacocoTestReport.xml
-
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck
 

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -22,7 +22,7 @@ jobs:
 
             - name: SonarQube BaseURL 삽입
               run: |
-                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
+                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> $(pwd)/sonar-project.properties
 
             - name: Gradle 패키지 캐싱
               uses: actions/cache@v2
@@ -35,13 +35,13 @@ jobs:
                       ${{ runner.os }}-gradle-
 
             - name: 빌드 출력 확인
-              run: cat build/reports/jacoco/test/jacocoTestReport.xml
+              run: cat $(pwd)/build/reports/jacoco/test/jacocoTestReport.xml
 
             - name: sonar-project.properties 파일 내용 확인
               run: |
-                  grep "sonar.coverage.jacoco.xmlReportPaths" sonar-project.properties
-                  grep "sonar.projectKey" sonar-project.properties
-                  grep "sonar.core.serverBaseURL" sonar-project.properties
+                  grep "sonar.coverage.jacoco.xmlReportPaths" $(pwd)/sonar-project.properties
+                  grep "sonar.projectKey" $(pwd)/sonar-project.properties
+                  grep "sonar.core.serverBaseURL" $(pwd)/sonar-project.properties
 
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -1,4 +1,4 @@
-name: PR 제출 시 ktlint 검사 실행
+name: PR 제출 시 코드 검사 및 SonarQube 분석 실행
 
 on:
     pull_request:
@@ -7,7 +7,7 @@ on:
             - develop
 
 jobs:
-    ktlint:
+    build:
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -33,8 +33,8 @@ jobs:
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck
 
-            - name: SonarQube 프로젝트키 삽입
-              run: echo "sonar.projectKey=${{ secrets.SONARQUBE_PROJECT_KEY }}" >> sonar-project.properties
+            - name: SonarQube BaseURL 삽입
+              run: echo "sonar.core.serverBaseURL=${{ secrets.SONARQUBE_EC2_HOST }}" >> sonar-project.properties
 
             - name: SonarQube 분석 실행 후 PR Commant 작성
               uses: sonarsource/sonarqube-scan-action@master

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     kotlin("plugin.spring") version "1.9.24"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     id("com.google.cloud.tools.jib") version "3.4.0"
+    jacoco
 }
 
 group = "com.sbl"
@@ -68,6 +69,23 @@ kotlin {
     }
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        html.required.set(true)
+        xml.required.set(false)
+        csv.required.set(false)
+    }
+}
+
 jib {
     from {
         image = "openjdk:17-slim"
@@ -87,8 +105,4 @@ jib {
     container {
         jvmFlags = listOf("-Xms128m", "-Xmx128m")
     }
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,20 +87,6 @@ tasks.jacocoTestReport {
     }
 }
 
-sonarqube {
-    properties {
-        property(
-            "sonar.coverage.jacoco.xmlReportPaths",
-            project.layout.buildDirectory
-                .file("reports/jacoco/test/jacocoTestReport.xml")
-                .get()
-                .asFile.absolutePath,
-        )
-        property("sonar.projectKey", "SUIN-BUNDANG-LINE_Backend_AZDrXmI4FBe8ovYIAI-X")
-        property("sonar.projectName", "Backend")
-    }
-}
-
 jib {
     from {
         image = "openjdk:17-slim"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,8 +80,8 @@ tasks.test {
 
 tasks.jacocoTestReport {
     reports {
-        html.required.set(true)
-        xml.required.set(false)
+        html.required.set(false)
+        xml.required.set(true)
         csv.required.set(false)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,15 @@ tasks.jacocoTestReport {
 
 sonarqube {
     properties {
-        property("sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            project.layout.buildDirectory
+                .file("reports/jacoco/test/jacocoTestReport.xml")
+                .get()
+                .asFile.absolutePath,
+        )
+        property("sonar.projectKey", "SUIN-BUNDANG-LINE_Backend_AZDrXmI4FBe8ovYIAI-X")
+        property("sonar.projectName", "Backend")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     kotlin("plugin.spring") version "1.9.24"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     id("com.google.cloud.tools.jib") version "3.4.0"
+    id("org.sonarqube") version "4.4.1.3373"
     jacoco
 }
 
@@ -83,6 +84,12 @@ tasks.jacocoTestReport {
         html.required.set(false)
         xml.required.set(true)
         csv.required.set(false)
+    }
+}
+
+sonarqube {
+    properties {
+        property("sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
     }
 }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=SUIN-BUNDANG-LINE_Backend_AZDrXmI4FBe8ovYIAI-X
+sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,2 @@
 sonar.projectKey=SUIN-BUNDANG-LINE_Backend_AZDrXmI4FBe8ovYIAI-X
-sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/test/jacocoTestReport.xml
+sonar.junit.reportPaths=build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
## 📢 설명
- Jacoco 추가, 코드 커버리지 리포트 생성하도록 구현
- PR 작성 시 CI 파이프라인에서 SonarQube 분석 실행 후 PR Commant 작성하도록 구현

## ✅ 체크 리스트
- [x] PR 작성 시 PR 코멘트 작성이 되는지 확인
- [x] PR 코멘트의 테스트 커버리지 확인
