### PR TITLE
[SBL-69] user profile cookie

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
@@ -22,7 +22,6 @@ class CustomOAuth2Service(
     private val sessionRegistry: SessionRegistry,
     private val userAdapter: UserAdapter,
 ) : DefaultOAuth2UserService() {
-    // TODO: @Transactional 추가
     override fun loadUser(oAuth2UserRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User: OAuth2User = super.loadUser(oAuth2UserRequest)
 
@@ -43,7 +42,7 @@ class CustomOAuth2Service(
                 )
 
         userAdapter.save(upsertedUser)
-        return CustomOAuth2User(upsertedUser.id, upsertedUser.role, oAuth2User.attributes)
+        return CustomOAuth2User(upsertedUser.id, upsertedUser.role, upsertedUser.nickname, oAuth2User.attributes)
     }
 
     private fun getOAuth2UserInfo(

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
@@ -22,6 +22,7 @@ class CustomOAuth2Service(
     private val sessionRegistry: SessionRegistry,
     private val userAdapter: UserAdapter,
 ) : DefaultOAuth2UserService() {
+    // TODO: @Transactional 추가
     override fun loadUser(oAuth2UserRequest: OAuth2UserRequest): OAuth2User {
         val oAuth2User: OAuth2User = super.loadUser(oAuth2UserRequest)
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2User.kt
@@ -1,14 +1,16 @@
 package com.sbl.sulmun2yong.global.config.oauth2
 
 import com.sbl.sulmun2yong.user.domain.UserRole
+import com.sbl.sulmun2yong.user.dto.DefaultUserProfile
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.core.user.OAuth2User
 import java.util.UUID
 
-class CustomOAuth2User(
+data class CustomOAuth2User(
     private val id: UUID,
     private val role: UserRole,
+    private val nickname: String,
     // TODO: attributes 통일
     private val attributes: MutableMap<String, Any>,
 ) : OAuth2User {
@@ -21,15 +23,9 @@ class CustomOAuth2User(
         return mutableListOf(authorities)
     }
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) {
-            return true
-        }
-        if (other !is CustomOAuth2User) {
-            return false
-        }
-        return id == other.id
-    }
-
-    override fun hashCode(): Int = id.hashCode()
+    fun getUserDefaultProfile(): DefaultUserProfile =
+        DefaultUserProfile(
+            id = id,
+            nickname = nickname,
+        )
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2User.kt
@@ -23,7 +23,7 @@ data class CustomOAuth2User(
         return mutableListOf(authorities)
     }
 
-    fun getUserDefaultProfile(): DefaultUserProfile =
+    fun getDefaultUserProfile(): DefaultUserProfile =
         DefaultUserProfile(
             id = id,
             nickname = nickname,

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
@@ -1,8 +1,11 @@
 package com.sbl.sulmun2yong.global.config.oauth2.handler
 
+import com.sbl.sulmun2yong.global.config.oauth2.CustomOAuth2User
+import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 
 class CustomAuthenticationSuccessHandler(
@@ -11,10 +14,23 @@ class CustomAuthenticationSuccessHandler(
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        authentication: org.springframework.security.core.Authentication?,
+        authentication: Authentication,
     ) {
         // 상태 코드 설정
         response.status = HttpStatus.OK.value()
+
+        val principal = authentication.principal
+        val defaultUserProfile =
+            if (principal is CustomOAuth2User) {
+                principal.getUserDefaultProfile()
+            } else {
+                throw IllegalArgumentException("CustomOAuth2User 타입이 아닙니다.")
+            }
+
+        // 기본 프로필 쿠키 생성
+        val cookie = Cookie("user-profile", defaultUserProfile.toBase64Json())
+        cookie.path = "/"
+        response.addCookie(cookie)
 
         // 리디렉트
         response.sendRedirect("$baseUrl/")

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
@@ -22,7 +22,7 @@ class CustomAuthenticationSuccessHandler(
         val principal = authentication.principal
         val defaultUserProfile =
             if (principal is CustomOAuth2User) {
-                principal.getUserDefaultProfile()
+                principal.getDefaultUserProfile()
             } else {
                 throw IllegalArgumentException("CustomOAuth2User 타입이 아닙니다.")
             }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/ResetSession.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/ResetSession.kt
@@ -14,10 +14,15 @@ class ResetSession {
             request.session.invalidate()
 
             // 쿠키 삭제
-            val cookie = Cookie("JSESSIONID", null)
-            cookie.path = "/"
-            cookie.maxAge = 0
-            response.addCookie(cookie)
+            val expiredJsessionIdCookie = Cookie("JSESSIONID", null)
+            expiredJsessionIdCookie.path = "/"
+            expiredJsessionIdCookie.maxAge = 0
+            response.addCookie(expiredJsessionIdCookie)
+
+            val expiredUserProfileCookie = Cookie("user-profile", null)
+            expiredUserProfileCookie.path = "/"
+            expiredUserProfileCookie.maxAge = 0
+            response.addCookie(expiredUserProfileCookie)
         }
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/dto/DefaultUserProfile.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/dto/DefaultUserProfile.kt
@@ -1,0 +1,17 @@
+package com.sbl.sulmun2yong.user.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.Base64
+import java.util.UUID
+
+data class DefaultUserProfile(
+    @JsonProperty("id") val id: UUID,
+    @JsonProperty("nickname") val nickname: String,
+) {
+    fun toBase64Json(): String {
+        val objectMapper = ObjectMapper()
+        val json = objectMapper.writeValueAsString(this)
+        return Base64.getEncoder().encodeToString(json.toByteArray())
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/dto/DefaultUserProfile.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/dto/DefaultUserProfile.kt
@@ -1,13 +1,12 @@
 package com.sbl.sulmun2yong.user.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.Base64
 import java.util.UUID
 
 data class DefaultUserProfile(
-    @JsonProperty("id") val id: UUID,
-    @JsonProperty("nickname") val nickname: String,
+    val id: UUID,
+    val nickname: String,
 ) {
     fun toBase64Json(): String {
         val objectMapper = ObjectMapper()


### PR DESCRIPTION
## 📢 설명
로그인시 기본 프로필 JSON을 base64 인코딩하여 보내줍니다
```
{"id":"d918bf9d-f8b3-4a0f-b4a6-b83ecb4a4d6f","nickname":"감동적인 황새"}
```
to
```
eyJpZCI6ImQ5MThiZjlkLWY4YjMtNGEwZi1iNGE2LWI4M2VjYjRhNGQ2ZiIsIm5pY2tuYW1lIjoi6rCQ64+Z7KCB7J24IO2ZqeyDiCJ9
```

## ✅ 체크 리스트
- [ ] 500 error에 대한 논의
현재는 임시로 이렇게 해놓은 상태
```
src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt

 val principal = authentication.principal
        val defaultUserProfile =
            if (principal is CustomOAuth2User) {
                principal.getUserDefaultProfile()
            } else {
                throw IllegalArgumentException("CustomOAuth2User 타입이 아닙니다.")
            }
```
사용자 입력에 의한 것이 아닌 spring security 에러이므로 500 에러라고 보입니다 이럴 때는 어떻게 처리할 지 논의가 필요해보입니다 

- [x] 그 외 코드 리뷰
- [ ]  프론트엔드의 base64 디코딩에 대한 컨펌
