### PR TITLE
[SBL-46] Drawing History

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingBoard.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingBoard.kt
@@ -4,7 +4,6 @@ import com.sbl.sulmun2yong.drawing.domain.drawingResult.DrawingResult
 import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
 import com.sbl.sulmun2yong.drawing.exception.AlreadySelectedTicketException
 import com.sbl.sulmun2yong.drawing.exception.InvalidDrawingBoardException
-import com.sbl.sulmun2yong.drawing.exception.OutOfTicketException
 import java.util.UUID
 
 class DrawingBoard(
@@ -13,17 +12,16 @@ class DrawingBoard(
     val tickets: List<Ticket>,
 ) {
     val selectedTicketCount: Int
+    val remainingTicketCount: Int
 
     init {
         selectedTicketCount = calcSelectedTicketCount()
-        val remainingTicketCount = this.tickets.size - selectedTicketCount
-
-        if (remainingTicketCount <= 0) {
-            throw OutOfTicketException()
-        }
+        remainingTicketCount = this.tickets.size - selectedTicketCount
     }
 
     fun getDrawingResult(selectedIndex: Int): DrawingResult {
+        validateOutOfTicket()
+
         val selectedTicket = this.tickets[selectedIndex]
         validateTicketIsSelected(selectedTicket)
 
@@ -39,6 +37,12 @@ class DrawingBoard(
                 DrawingResult.NonWinner(
                     changedDrawingBoard = changedDrawingBoard,
                 )
+        }
+    }
+
+    private fun validateOutOfTicket() {
+        if (remainingTicketCount <= 0) {
+            throw AlreadySelectedTicketException()
         }
     }
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistory.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistory.kt
@@ -8,7 +8,7 @@ class DrawingHistory(
     val id: UUID,
     val participantId: UUID,
     val phoneNumber: PhoneNumber,
-    val drawingBoardId: UUID,
+    val surveyId: UUID,
     val selectedTicketIndex: Int,
     val ticket: Ticket,
 ) {
@@ -16,7 +16,7 @@ class DrawingHistory(
         fun create(
             participantId: UUID,
             phoneNumber: PhoneNumber,
-            drawingBoardId: UUID,
+            surveyId: UUID,
             selectedTicketIndex: Int,
             ticket: Ticket,
         ): DrawingHistory =
@@ -24,7 +24,7 @@ class DrawingHistory(
                 UUID.randomUUID(),
                 participantId,
                 phoneNumber,
-                drawingBoardId,
+                surveyId,
                 selectedTicketIndex,
                 ticket,
             )

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistoryGroup.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistoryGroup.kt
@@ -1,0 +1,9 @@
+package com.sbl.sulmun2yong.drawing.domain
+
+import java.util.UUID
+
+class DrawingHistoryGroup(
+    val surveyId: UUID,
+    val count: Int,
+    val histories: List<DrawingHistory>,
+)

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/DrawingHistoryDTOGroupedBySurveyId.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/DrawingHistoryDTOGroupedBySurveyId.kt
@@ -1,0 +1,10 @@
+package com.sbl.sulmun2yong.drawing.dto
+
+import com.sbl.sulmun2yong.drawing.entity.DrawingHistoryDocument
+import java.util.UUID
+
+data class DrawingHistoryDTOGroupedBySurveyId(
+    val id: UUID,
+    val count: Int,
+    val items: List<DrawingHistoryDocument>,
+)

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/response/DrawingHistoryGroupListResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/response/DrawingHistoryGroupListResponse.kt
@@ -1,0 +1,19 @@
+package com.sbl.sulmun2yong.drawing.dto.response
+
+import com.sbl.sulmun2yong.drawing.domain.DrawingHistoryGroup
+
+class DrawingHistoryGroupListResponse(
+    val count: Int,
+    val DrawingHistoryGroupList: List<DrawingHistoryGroupResponse>,
+) {
+    companion object {
+        fun of(drawingHistoryGroupList: List<DrawingHistoryGroup>) =
+            DrawingHistoryGroupListResponse(
+                count = drawingHistoryGroupList.size,
+                DrawingHistoryGroupList =
+                    drawingHistoryGroupList.map {
+                        DrawingHistoryGroupResponse.of(it)
+                    },
+            )
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/response/DrawingHistoryGroupResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/response/DrawingHistoryGroupResponse.kt
@@ -1,0 +1,22 @@
+package com.sbl.sulmun2yong.drawing.dto.response
+
+import com.sbl.sulmun2yong.drawing.domain.DrawingHistoryGroup
+import java.util.UUID
+
+class DrawingHistoryGroupResponse(
+    val surveyId: UUID,
+    val count: Int,
+    val histories: List<DrawingHistoryResponse>,
+) {
+    companion object {
+        fun of(drawingHistoryGroup: DrawingHistoryGroup) =
+            DrawingHistoryGroupResponse(
+                surveyId = drawingHistoryGroup.surveyId,
+                count = drawingHistoryGroup.count,
+                histories =
+                    drawingHistoryGroup.histories.map {
+                        DrawingHistoryResponse.of(it)
+                    },
+            )
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/response/DrawingHistoryResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/dto/response/DrawingHistoryResponse.kt
@@ -1,0 +1,24 @@
+package com.sbl.sulmun2yong.drawing.dto.response
+
+import com.sbl.sulmun2yong.drawing.domain.DrawingHistory
+import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
+import java.util.UUID
+
+class DrawingHistoryResponse(
+    val id: UUID,
+    val participantId: UUID,
+    val phoneNumber: String,
+    val selectedTicketIndex: Int,
+    val ticket: Ticket,
+) {
+    companion object {
+        fun of(drawingHistory: DrawingHistory) =
+            DrawingHistoryResponse(
+                id = drawingHistory.id,
+                participantId = drawingHistory.participantId,
+                phoneNumber = drawingHistory.phoneNumber.value,
+                selectedTicketIndex = drawingHistory.selectedTicketIndex,
+                ticket = drawingHistory.ticket,
+            )
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/entity/DrawingHistoryDocument.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/entity/DrawingHistoryDocument.kt
@@ -13,7 +13,7 @@ data class DrawingHistoryDocument(
     val id: UUID,
     val participantId: UUID,
     val phoneNumber: String,
-    val drawingBoardId: UUID,
+    val surveyId: UUID,
     val selectedTicketIndex: Int,
     val ticket: Ticket,
 ) {
@@ -23,7 +23,7 @@ data class DrawingHistoryDocument(
                 id = drawingHistory.id,
                 participantId = drawingHistory.participantId,
                 phoneNumber = drawingHistory.phoneNumber.value,
-                drawingBoardId = drawingHistory.drawingBoardId,
+                surveyId = drawingHistory.surveyId,
                 selectedTicketIndex = drawingHistory.selectedTicketIndex,
                 ticket = drawingHistory.ticket,
             )
@@ -34,7 +34,7 @@ data class DrawingHistoryDocument(
             id = id,
             participantId = participantId,
             phoneNumber = PhoneNumber.createWithNonNullable(phoneNumber),
-            drawingBoardId = drawingBoardId,
+            surveyId = surveyId,
             selectedTicketIndex = selectedTicketIndex,
             ticket = ticket,
         )

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/exception/InvalidDrawingHistoryException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/exception/InvalidDrawingHistoryException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.drawing.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidDrawingHistoryException : BusinessException(ErrorCode.INVALID_DRAWING_HISTORY)

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/repository/DrawingHistoryRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/repository/DrawingHistoryRepository.kt
@@ -1,6 +1,8 @@
 package com.sbl.sulmun2yong.drawing.repository
 
+import com.sbl.sulmun2yong.drawing.dto.DrawingHistoryDTOGroupedBySurveyId
 import com.sbl.sulmun2yong.drawing.entity.DrawingHistoryDocument
+import org.springframework.data.mongodb.repository.Aggregation
 import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.data.mongodb.repository.Query
 import org.springframework.stereotype.Repository
@@ -9,9 +11,43 @@ import java.util.UUID
 
 @Repository
 interface DrawingHistoryRepository : MongoRepository<DrawingHistoryDocument, UUID> {
-    @Query("{ '\$or': [ { 'participantId': ?0 }, { 'phoneNumber': ?1 } ] }")
-    fun findByParticipantIdOrPhoneNumber(
+    @Query(
+        value = "{ '\$and': [ { 'surveyId': ?0 }, { '\$or': [ { 'participantId': ?1 }, { 'phoneNumber': ?2 } ] } ] }",
+    )
+    fun findBySurveyIdAndParticipantIdOrPhoneNumber(
+        surveyId: UUID,
         participantId: UUID,
         phoneNumber: String,
     ): Optional<DrawingHistoryDocument>
+
+    @Aggregation(
+        pipeline = [
+            "{ '\$match': { 'surveyId': ?0 } }",
+            "{ '\$group': { '_id': '\$surveyId', 'count': { '\$sum': 1 }, 'items': { '\$push': '\$\$ROOT' } } }",
+        ],
+    )
+    fun findBySurveyId(surveyId: UUID): Optional<DrawingHistoryDTOGroupedBySurveyId>
+
+    @Aggregation(
+        pipeline = [
+            "{ '\$match': { 'ticket._class': 'com.sbl.sulmun2yong.drawing.domain.ticket.Ticket\$Winning', 'surveyId': ?0 } }",
+            "{ '\$group': { '_id': '\$surveyId', 'count': { '\$sum': 1 }, 'items': { '\$push': '\$\$ROOT' } } }",
+        ],
+    )
+    fun findBySurveyIdForWinner(surveyId: UUID): Optional<DrawingHistoryDTOGroupedBySurveyId>
+
+    @Aggregation(
+        pipeline = [
+            "{ '\$group': { '_id': '\$surveyId', 'count': { '\$sum': 1 }, 'items': { '\$push': '$\$ROOT' } } }",
+        ],
+    )
+    fun findGroupedSurveyId(): List<DrawingHistoryDTOGroupedBySurveyId>
+
+    @Aggregation(
+        pipeline = [
+            "{ '\$match': { 'ticket._class': 'com.sbl.sulmun2yong.drawing.domain.ticket.Ticket\$Winning' } }",
+            "{ '\$group': { '_id': '\$surveyId', 'count': { '\$sum': 1 }, 'items': { '\$push': '\$\$ROOT' } } }",
+        ],
+    )
+    fun findGroupedBySurveyIdForWinner(): List<DrawingHistoryDTOGroupedBySurveyId>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -30,6 +30,7 @@ enum class ErrorCode(
     ALREADY_SELECTED_TICKET(HttpStatus.BAD_REQUEST, "DR0004", "이미 선택된 티켓입니다."),
     ALREADY_PARTICIPATED_DRAWING(HttpStatus.BAD_REQUEST, "DR0005", "이미 참여한 추첨입니다."),
     FINISHED_DRAWING(HttpStatus.BAD_REQUEST, "DR0005", "이미 마감된 추첨입니다."),
+    INVALID_DRAWING_HISTORY(HttpStatus.BAD_REQUEST, "DR0006", "유효하지 않은 추첨 기록입니다."),
 
     // OAuth2 (OA)
     PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "OA0001", "지원하지 않는 소셜 로그인입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -3,6 +3,7 @@ package com.sbl.sulmun2yong.survey.adapter
 import com.sbl.sulmun2yong.survey.domain.Survey
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import com.sbl.sulmun2yong.survey.dto.request.SurveySortType
+import com.sbl.sulmun2yong.survey.entity.SurveyDocument
 import com.sbl.sulmun2yong.survey.exception.SurveyNotFoundException
 import com.sbl.sulmun2yong.survey.repository.SurveyRepository
 import org.springframework.data.domain.Page
@@ -41,5 +42,9 @@ class SurveyAdapter(
                 Sort.by("createdAt").descending()
             }
         }
+    }
+
+    fun save(survey: Survey) {
+        surveyRepository.save(SurveyDocument.from(survey))
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -48,6 +48,8 @@ data class Survey(
         require(expectedSectionId is SectionId.End) { throw InvalidSurveyResponseException() }
     }
 
+    fun finish() = copy(status = SurveyStatus.CLOSED)
+
     fun getRewardCount() = rewards.sumOf { it.count }
 
     private fun isSectionsUnique() = sections.size == sections.distinctBy { it.id }.size

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/AdminController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/AdminController.kt
@@ -1,13 +1,18 @@
 package com.sbl.sulmun2yong.user.controller
 
+import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupListResponse
+import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupResponse
 import com.sbl.sulmun2yong.user.controller.doc.AdminApiDoc
 import com.sbl.sulmun2yong.user.dto.response.UserSessionsResponse
 import com.sbl.sulmun2yong.user.service.AdminService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.session.SessionRegistry
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController("/api/v1/admin")
 class AdminController(
@@ -20,4 +25,16 @@ class AdminController(
         val allPrincipals = sessionRegistry.allPrincipals
         return ResponseEntity.ok(adminService.getAllLoggedInUsers(allPrincipals))
     }
+
+    @GetMapping("/drawing-history/{surveyId}")
+    override fun getDrawingHistory(
+        @PathVariable surveyId: UUID,
+        @RequestParam(defaultValue = "false") isWinnerOnly: Boolean,
+    ): ResponseEntity<DrawingHistoryGroupResponse> = ResponseEntity.ok(adminService.getDrawingHistory(surveyId, isWinnerOnly))
+
+    @GetMapping("/drawing-history/list")
+    @ResponseBody
+    override fun getDrawingHistoryList(
+        @RequestParam(defaultValue = "false") isWinnerOnly: Boolean,
+    ): ResponseEntity<DrawingHistoryGroupListResponse> = ResponseEntity.ok(adminService.getDrawingHistoryList(isWinnerOnly))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/AdminApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/AdminApiDoc.kt
@@ -1,11 +1,16 @@
 package com.sbl.sulmun2yong.user.controller.doc
 
+import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupListResponse
+import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupResponse
 import com.sbl.sulmun2yong.user.dto.response.UserSessionsResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import java.util.UUID
 
 @Tag(name = "Admin", description = "관리자 API")
 @RequestMapping("/api/v1/admin")
@@ -13,4 +18,17 @@ interface AdminApiDoc {
     @Operation(summary = "로그인한 사용자 조회")
     @GetMapping("/sessions/logged-in-users")
     fun getAllLoggedInUsers(): ResponseEntity<UserSessionsResponse>
+
+    @Operation(summary = "추첨 기록 설문 id로 조회")
+    @GetMapping("/drawing-history/{surveyId}")
+    fun getDrawingHistory(
+        @PathVariable surveyId: UUID,
+        @RequestParam(defaultValue = "false") isWinnerOnly: Boolean,
+    ): ResponseEntity<DrawingHistoryGroupResponse>
+
+    @Operation(summary = "추첨 기록 리스트 조회")
+    @GetMapping("/drawing-history/list")
+    fun getDrawingHistoryList(
+        @RequestParam(defaultValue = "false") isWinnerOnly: Boolean,
+    ): ResponseEntity<DrawingHistoryGroupListResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/service/AdminService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/service/AdminService.kt
@@ -1,9 +1,30 @@
 package com.sbl.sulmun2yong.user.service
 
+import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
+import com.sbl.sulmun2yong.drawing.adapter.DrawingHistoryAdapter
+import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupListResponse
+import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupResponse
 import com.sbl.sulmun2yong.user.dto.response.UserSessionsResponse
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
-class AdminService {
+class AdminService(
+    val drawingHistoryAdapter: DrawingHistoryAdapter,
+    val drawingBoardAdapter: DrawingBoardAdapter,
+) {
     fun getAllLoggedInUsers(customOAuth2Users: List<Any>): UserSessionsResponse = UserSessionsResponse(customOAuth2Users)
+
+    fun getDrawingHistory(
+        surveyId: UUID,
+        isWinnerOnly: Boolean,
+    ): DrawingHistoryGroupResponse {
+        val drawingHistoryGroup = drawingHistoryAdapter.getBySurveyId(surveyId, isWinnerOnly)
+        return DrawingHistoryGroupResponse.of(drawingHistoryGroup)
+    }
+
+    fun getDrawingHistoryList(isWinnerOnly: Boolean): DrawingHistoryGroupListResponse {
+        val drawingHistoryGroupList = drawingHistoryAdapter.getDrawingHistoryGroupList(isWinnerOnly)
+        return DrawingHistoryGroupListResponse.of(drawingHistoryGroupList)
+    }
 }

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/BoardMakingTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/BoardMakingTest.kt
@@ -40,6 +40,7 @@ class BoardMakingTest {
         assertEquals(0, drawingBoard.selectedTicketCount)
         assertEquals(surveyId, drawingBoard.surveyId)
         assertEquals(boardSize, drawingBoard.tickets.size)
+        assertEquals(boardSize, drawingBoard.remainingTicketCount)
     }
 
     @Test

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistoryTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistoryTest.kt
@@ -1,36 +1,18 @@
 package com.sbl.sulmun2yong.drawing.domain
 
-import com.sbl.sulmun2yong.global.data.PhoneNumber
+import com.sbl.sulmun2yong.fixture.drawing.DrawingHistoryFixtureFactory
+import com.sbl.sulmun2yong.fixture.drawing.DrawingHistoryFixtureFactory.drawingBoardId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 class DrawingHistoryTest {
     @Test
     fun `추첨 기록을 만든다`() {
         // given
-        val participantId = UUID.randomUUID()
-        val phoneNumber = PhoneNumber("010-1234-5678")
-        val drawingBoardId = UUID.randomUUID()
-        val selectedTicketIndex = 0
-        val ticket =
-            com.sbl.sulmun2yong.drawing.domain.ticket.Ticket.Winning(
-                "테스트 아메리카노",
-                "테스트",
-                false,
-            )
-        // when
-        val drawingHistory =
-            DrawingHistory.create(
-                participantId,
-                phoneNumber,
-                drawingBoardId,
-                selectedTicketIndex,
-                ticket,
-            )
+        val drawingHistory = DrawingHistoryFixtureFactory.createdDrawingHistory()
 
-        // then
+        // when, then
         with(drawingHistory) {
             assertNotNull(id)
             assertEquals(participantId, this.participantId)
@@ -38,6 +20,29 @@ class DrawingHistoryTest {
             assertEquals(drawingBoardId, this.surveyId)
             assertEquals(selectedTicketIndex, this.selectedTicketIndex)
             assertEquals(ticket, this.ticket)
+        }
+    }
+
+    @Test
+    fun `추첨 기록을 그룹을 만든다`() {
+        // given
+        val drawingHistory1 = DrawingHistoryFixtureFactory.createdDrawingHistory()
+        val drawingHistory2 = DrawingHistoryFixtureFactory.createdDrawingHistory()
+        val drawingHistory3 = DrawingHistoryFixtureFactory.createdDrawingHistory()
+
+        // when
+        val drawingHistoryGroup =
+            DrawingHistoryGroup(
+                surveyId = drawingBoardId,
+                count = 3,
+                histories = listOf(drawingHistory1, drawingHistory2, drawingHistory3),
+            )
+
+        // then
+        with(drawingHistoryGroup) {
+            assertEquals(drawingBoardId, this.surveyId)
+            assertEquals(3, this.count)
+            assertEquals(3, this.histories.size)
         }
     }
 }

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistoryTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingHistoryTest.kt
@@ -35,7 +35,7 @@ class DrawingHistoryTest {
             assertNotNull(id)
             assertEquals(participantId, this.participantId)
             assertEquals(phoneNumber, this.phoneNumber)
-            assertEquals(drawingBoardId, this.drawingBoardId)
+            assertEquals(drawingBoardId, this.surveyId)
             assertEquals(selectedTicketIndex, this.selectedTicketIndex)
             assertEquals(ticket, this.ticket)
         }

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingTest.kt
@@ -3,7 +3,6 @@ package com.sbl.sulmun2yong.drawing.domain
 import com.sbl.sulmun2yong.drawing.domain.drawingResult.DrawingResult
 import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
 import com.sbl.sulmun2yong.drawing.exception.AlreadySelectedTicketException
-import com.sbl.sulmun2yong.drawing.exception.OutOfTicketException
 import com.sbl.sulmun2yong.fixture.drawing.DrawingBoardFixtureFactory
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -72,8 +71,11 @@ class DrawingTest {
 
     @Test
     fun `이미 전부 추첨 완료된 보드에서 추첨하면 오류가 발생한다`() {
-        // given, when, then
-        assertThrows<OutOfTicketException> { DrawingBoardFixtureFactory.createAllSelectedDrawingBoard() }
+        // given
+        val drawingBoard = DrawingBoardFixtureFactory.createAllSelectedDrawingBoard()
+
+        // when, then
+        assertThrows<AlreadySelectedTicketException> { drawingBoard.getDrawingResult(3) }
     }
 
     @Test

--- a/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingHistoryFixtureFactory.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingHistoryFixtureFactory.kt
@@ -1,0 +1,27 @@
+package com.sbl.sulmun2yong.fixture.drawing
+
+import com.sbl.sulmun2yong.drawing.domain.DrawingHistory
+import com.sbl.sulmun2yong.global.data.PhoneNumber
+import java.util.UUID
+
+object DrawingHistoryFixtureFactory {
+    val participantId = UUID.randomUUID()
+    val phoneNumber = PhoneNumber("010-1234-5678")
+    val drawingBoardId = UUID.randomUUID()
+    val selectedTicketIndex = 0
+    val ticket =
+        com.sbl.sulmun2yong.drawing.domain.ticket.Ticket.Winning(
+            "테스트 아메리카노",
+            "테스트",
+            false,
+        )
+
+    fun createdDrawingHistory(): DrawingHistory =
+        DrawingHistory.create(
+            participantId,
+            phoneNumber,
+            drawingBoardId,
+            selectedTicketIndex,
+            ticket,
+        )
+}

--- a/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingHistoryFixtureFactory.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingHistoryFixtureFactory.kt
@@ -13,7 +13,7 @@ object DrawingHistoryFixtureFactory {
         com.sbl.sulmun2yong.drawing.domain.ticket.Ticket.Winning(
             "테스트 아메리카노",
             "테스트",
-            false,
+            true,
         )
 
     fun createdDrawingHistory(): DrawingHistory =


### PR DESCRIPTION
## 📢 설명
- 참가자 중복은 SurveyID && (ParticipantId || phonenumber)로 존재해야하므로 해당 로직 수정
- 추첨 로그 조회 API, 도메인 구현
- validateOutOfTicket 검증 위치 변경
- history는 더이상 drawingBoardId가 아닌 SurveyId를 가지고 있습니다
- 설문이 CLOSED 상태이면 추첨을  진행할 수 없습니다. 한편으로는 남은 티켓 개수가 0이되면  설문이 CLOSED  상태가 됩니다 


## ✅ 체크 리스트
- [ ] drawing.domain 커버리지가 100% 임을 확인
- [ ] 변경된 참가자 중복 로직 검증
- [ ] 로그 조회 결과 JSON의 구조 검토
- [ ] 그 외 코드 리뷰
