### PR TITLE
[SBL-76] CI 파이프라인에서 SonarQube 코드 분석 대신 Jacoco 커버리지 리포트만 넣도록 수정

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -6,6 +6,10 @@ on:
             - main
             - develop
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -37,9 +41,10 @@ jobs:
               run: ./gradlew ktlintCheck
 
             - name: 테스트 커버리지 리포트 PR Commant 추가
-              id: jacoco
               uses: madrapps/jacoco-report@v1.6
               with:
-                  title: Test Coverage Report
-                  paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+                  title: 테스트 커버리지 리포트
+                  paths: build/reports/jacoco/test/jacocoTestReport.xml
                   token: ${{ secrets.GITHUB_TOKEN }}
+                  min-coverage-overall: 0
+                  min-coverage-changed-files: 0

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -1,4 +1,4 @@
-name: PR 제출 시 코드 검사 및 SonarQube 분석 실행
+name: PR 제출 시 코드 검사 및 코드 커버리지 리포트 작성
 
 on:
     pull_request:
@@ -20,10 +20,6 @@ jobs:
                   distribution: 'temurin'
                   java-version: '17'
 
-            - name: SonarQube BaseURL 삽입
-              run: |
-                  echo "sonar.host.url=${{ secrets.SONARQUBE_EC2_HOST }}" >> $(pwd)/sonar-project.properties
-
             - name: Gradle 패키지 캐싱
               uses: actions/cache@v2
               with:
@@ -40,11 +36,10 @@ jobs:
             - name: ktlint 검사 실행
               run: ./gradlew ktlintCheck
 
-            - name: SonarQube 분석 실행 후 PR Commant 작성
-              uses: sonarsource/sonarqube-scan-action@master
-              env:
-                  SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
-                  SONAR_HOST_URL: ${{ secrets.SONARQUBE_EC2_HOST }}
+            - name: 테스트 커버리지 리포트 PR Commant 추가
+              id: jacoco
+              uses: madrapps/jacoco-report@v1.6
               with:
-                  args: >
-                      -Dsonar.branch.name=${{ github.head_ref }}
+                  title: Test Coverage Report
+                  paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,0 @@
-sonar.projectKey=SUIN-BUNDANG-LINE_Backend_AZDrXmI4FBe8ovYIAI-X
-sonar.junit.reportPaths=build/reports/jacoco/test/jacocoTestReport.xml


### PR DESCRIPTION
## 📢 설명
- sonarqube의 유지보수 비용과 효과를 비교했을 때, sonarqube가 주는 이득이 적다 생각하여 sonarqube 제거
- 대신 jacoco test coverage report를 추가하도록 수정

## ✅ 체크 리스트
- [x] PR 제출 시 CI 파이프라인이 정상적으로 작동하여 code coverage report가 잘 나오는지 확인
