### PR TITLE
[SBL-68] 설문 제작 정보 API 구현, 설문 저장 API 수정

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - main
             - develop
+    workflow_dispatch: # 수동 실행 이벤트 추가
 
 permissions:
     contents: read
@@ -16,16 +17,16 @@ jobs:
 
         steps:
             - name: 코드 체크아웃
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: JDK 17 설정
-              uses: actions/setup-java@v2
+              uses: actions/setup-java@v3
               with:
                   distribution: 'temurin'
                   java-version: '17'
 
             - name: Gradle 패키지 캐싱
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: |
                       ~/.gradle/caches

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingBoard.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingBoard.kt
@@ -4,6 +4,7 @@ import com.sbl.sulmun2yong.drawing.domain.drawingResult.DrawingResult
 import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
 import com.sbl.sulmun2yong.drawing.exception.AlreadySelectedTicketException
 import com.sbl.sulmun2yong.drawing.exception.InvalidDrawingBoardException
+import com.sbl.sulmun2yong.survey.domain.Reward
 import java.util.UUID
 
 class DrawingBoard(

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/Reward.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/domain/Reward.kt
@@ -1,7 +1,0 @@
-package com.sbl.sulmun2yong.drawing.domain
-
-data class Reward(
-    val name: String,
-    val category: String,
-    val count: Int,
-)

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardService.kt
@@ -4,7 +4,6 @@ import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
 import com.sbl.sulmun2yong.drawing.adapter.DrawingHistoryAdapter
 import com.sbl.sulmun2yong.drawing.domain.DrawingBoard
 import com.sbl.sulmun2yong.drawing.domain.DrawingHistory
-import com.sbl.sulmun2yong.drawing.domain.Reward
 import com.sbl.sulmun2yong.drawing.domain.drawingResult.DrawingResult
 import com.sbl.sulmun2yong.drawing.dto.response.DrawingBoardResponse
 import com.sbl.sulmun2yong.drawing.dto.response.DrawingResultResponse
@@ -13,6 +12,7 @@ import com.sbl.sulmun2yong.drawing.exception.FinishedDrawingException
 import com.sbl.sulmun2yong.global.data.PhoneNumber
 import com.sbl.sulmun2yong.survey.adapter.ParticipantAdapter
 import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
+import com.sbl.sulmun2yong.survey.domain.Reward
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
@@ -96,7 +96,7 @@ class SecurityConfig(
                 authorize("/api/v1/admin/**", hasRole("ADMIN"))
                 authorize("/api/v1/user/**", authenticated)
                 // TODO: 추후에 AUTHENTICATED_USER 로 수정
-                authorize("/api/v1/surveys/workbench**", hasRole("ADMIN"))
+                authorize("/api/v1/surveys/workbench/**", hasRole("ADMIN"))
                 authorize("/**", permitAll)
             }
             exceptionHandling {

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -34,6 +34,7 @@ class SurveyManagementController(
         surveyManagementService.saveSurvey(
             surveySaveRequest = surveySaveRequest,
             makerId = id,
+            surveyId = surveyId,
         ),
     )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -5,6 +5,7 @@ import com.sbl.sulmun2yong.survey.controller.doc.SurveyManagementApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.service.SurveyManagementService
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -35,4 +36,9 @@ class SurveyManagementController(
             makerId = id,
         ),
     )
+
+    @GetMapping("/{surveyId}")
+    override fun getSurveyMakeInfo(
+        @PathVariable("surveyId") surveyId: UUID,
+    ) = ResponseEntity.ok(surveyManagementService.getSurveyMakeInfo(surveyId))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -3,10 +3,12 @@ package com.sbl.sulmun2yong.survey.controller.doc
 import com.sbl.sulmun2yong.global.annotation.LoginUser
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
+import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveySaveResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -29,4 +31,10 @@ interface SurveyManagementApiDoc {
         @LoginUser id: UUID,
         @RequestBody surveySaveRequest: SurveySaveRequest,
     ): ResponseEntity<SurveySaveResponse>
+
+    @Operation(summary = "설문 제작 정보 API")
+    @GetMapping("/{surveyId}")
+    fun getSurveyMakeInfo(
+        @PathVariable("surveyId") surveyId: UUID,
+    ): ResponseEntity<SurveyMakeInfoResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Reward.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Reward.kt
@@ -1,10 +1,8 @@
 package com.sbl.sulmun2yong.survey.domain
 
 import com.sbl.sulmun2yong.survey.exception.InvalidRewardException
-import java.util.UUID
 
 data class Reward(
-    val id: UUID,
     val name: String,
     val category: String,
     val count: Int,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
@@ -16,7 +16,6 @@ import java.util.Date
 import java.util.UUID
 
 data class SurveySaveRequest(
-    val id: UUID,
     val title: String,
     val description: String,
     // TODO: 섬네일의 URL이 우리 서비스의 S3 URL인지 확인하기

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
@@ -1,6 +1,5 @@
 package com.sbl.sulmun2yong.survey.dto.request
 
-import com.sbl.sulmun2yong.survey.domain.Reward
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import com.sbl.sulmun2yong.survey.domain.question.QuestionType
 import com.sbl.sulmun2yong.survey.domain.question.choice.Choice
@@ -34,13 +33,7 @@ data class SurveySaveRequest(
         val name: String,
         val category: String,
         val count: Int,
-    ) {
-        fun toSurveyDomain() = Reward(name = name, category = category, count = count)
-
-        fun toDrawingDomain() =
-            com.sbl.sulmun2yong.drawing.domain
-                .Reward(name = name, category = category, count = count)
-    }
+    )
 
     data class SectionCreateRequest(
         val id: UUID,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
@@ -35,7 +35,7 @@ data class SurveySaveRequest(
         val category: String,
         val count: Int,
     ) {
-        fun toSurveyDomain() = Reward(id = UUID.randomUUID(), name = name, category = category, count = count)
+        fun toSurveyDomain() = Reward(name = name, category = category, count = count)
 
         fun toDrawingDomain() =
             com.sbl.sulmun2yong.drawing.domain

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyMakeInfoResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyMakeInfoResponse.kt
@@ -1,0 +1,120 @@
+package com.sbl.sulmun2yong.survey.dto.response
+
+import com.sbl.sulmun2yong.survey.domain.Survey
+import com.sbl.sulmun2yong.survey.domain.SurveyStatus
+import com.sbl.sulmun2yong.survey.domain.question.Question
+import com.sbl.sulmun2yong.survey.domain.question.QuestionType
+import com.sbl.sulmun2yong.survey.domain.routing.RoutingStrategy
+import com.sbl.sulmun2yong.survey.domain.routing.RoutingType
+import com.sbl.sulmun2yong.survey.domain.section.Section
+import java.util.Date
+import java.util.UUID
+
+data class SurveyMakeInfoResponse(
+    val title: String,
+    val description: String,
+    val thumbnail: String?,
+    val publishedAt: Date?,
+    val finishedAt: Date,
+    val status: SurveyStatus,
+    val finishMessage: String,
+    val targetParticipantCount: Int,
+    val rewards: List<RewardMakeInfoResponse>,
+    val sections: List<SectionMakeInfoResponse>,
+) {
+    companion object {
+        fun of(survey: Survey) =
+            SurveyMakeInfoResponse(
+                title = survey.title,
+                description = survey.description,
+                thumbnail = survey.thumbnail,
+                publishedAt = survey.publishedAt,
+                finishedAt = survey.finishedAt,
+                status = survey.status,
+                finishMessage = survey.finishMessage,
+                targetParticipantCount = survey.targetParticipantCount,
+                rewards = survey.rewards.map { RewardMakeInfoResponse(it.name, it.category, it.count) },
+                sections = survey.sections.map { SectionMakeInfoResponse.from(it) },
+            )
+    }
+
+    data class RewardMakeInfoResponse(
+        val name: String,
+        val category: String,
+        val count: Int,
+    )
+
+    data class SectionMakeInfoResponse(
+        val id: UUID,
+        val title: String,
+        val description: String,
+        val questions: List<QuestionMakeInfoResponse>,
+        val routeDetails: RouteDetailsMakeInfoResponse,
+    ) {
+        companion object {
+            fun from(section: Section) =
+                SectionMakeInfoResponse(
+                    id = section.id.value,
+                    title = section.title,
+                    description = section.description,
+                    questions = section.questions.map { QuestionMakeInfoResponse.from(it) },
+                    routeDetails = RouteDetailsMakeInfoResponse.from(section.routingStrategy),
+                )
+        }
+    }
+
+    data class RouteDetailsMakeInfoResponse(
+        val type: RoutingType,
+        val nextSectionId: UUID?,
+        val keyQuestionId: UUID?,
+        val sectionRouteConfigs: List<RoutingConfigMakeInfoResponse>?,
+    ) {
+        companion object {
+            fun from(routingStrategy: RoutingStrategy) =
+                RouteDetailsMakeInfoResponse(
+                    type = routingStrategy.type,
+                    nextSectionId = if (routingStrategy is RoutingStrategy.SetByUser) routingStrategy.nextSectionId.value else null,
+                    keyQuestionId = if (routingStrategy is RoutingStrategy.SetByChoice) routingStrategy.keyQuestionId else null,
+                    sectionRouteConfigs =
+                        if (routingStrategy is RoutingStrategy.SetByChoice) {
+                            routingStrategy.routingMap.map { (choice, nextSectionId) ->
+                                RoutingConfigMakeInfoResponse(
+                                    content = choice.content,
+                                    nextSectionId = nextSectionId.value,
+                                )
+                            }
+                        } else {
+                            null
+                        },
+                )
+        }
+    }
+
+    data class RoutingConfigMakeInfoResponse(
+        val content: String?,
+        val nextSectionId: UUID?,
+    )
+
+    data class QuestionMakeInfoResponse(
+        val id: UUID,
+        val type: QuestionType,
+        val title: String,
+        val description: String,
+        val isRequired: Boolean,
+        val isAllowOther: Boolean,
+        val choices: List<String>?,
+    ) {
+        companion object {
+            fun from(question: Question) =
+                QuestionMakeInfoResponse(
+                    id = question.id,
+                    type = question.questionType,
+                    title = question.title,
+                    description = question.description,
+                    isRequired = question.isRequired,
+                    isAllowOther = question.choices?.isAllowOther ?: false,
+                    choices = question.choices?.standardChoices?.map { it.content },
+                )
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/entity/SurveyDocument.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/entity/SurveyDocument.kt
@@ -56,7 +56,6 @@ data class SurveyDocument(
 
         private fun Reward.toDocument() =
             RewardSubDocument(
-                rewardId = this.id,
                 name = this.name,
                 category = this.category,
                 count = this.count,
@@ -115,7 +114,6 @@ data class SurveyDocument(
     }
 
     data class RewardSubDocument(
-        val rewardId: UUID,
         val name: String,
         val category: String,
         val count: Int,
@@ -167,7 +165,6 @@ data class SurveyDocument(
 
     private fun RewardSubDocument.toDomain() =
         Reward(
-            id = this.rewardId,
             name = this.name,
             category = this.category,
             count = this.count,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -28,8 +28,8 @@ class SurveyManagementService(
 
     // TODO: 수정할 수 있는 설문의 정보에 제한이 필요
     // TODO: 추첨 보드 생성 로직을 startSurvey로 옮기기
-    // TODO: Reward 객체를 SurveyDomain의 것으로 통일하기
     fun saveSurvey(
+        surveyId: UUID,
         surveySaveRequest: SurveySaveRequest,
         makerId: UUID,
     ): SurveySaveResponse? {
@@ -38,7 +38,7 @@ class SurveyManagementService(
         val survey =
             with(surveySaveRequest) {
                 Survey(
-                    id = surveySaveRequest.id,
+                    id = surveyId,
                     title = this.title,
                     description = this.description,
                     thumbnail = this.thumbnail,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -3,6 +3,7 @@ package com.sbl.sulmun2yong.survey.service
 import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
 import com.sbl.sulmun2yong.drawing.domain.DrawingBoard
 import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
+import com.sbl.sulmun2yong.survey.domain.Reward
 import com.sbl.sulmun2yong.survey.domain.Survey
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
@@ -33,7 +34,7 @@ class SurveyManagementService(
         makerId: UUID,
     ): SurveySaveResponse? {
         val sectionIds = SectionIds.from(surveySaveRequest.sections.map { SectionId.Standard(it.id) })
-        val rewards = surveySaveRequest.rewards.map { it.toSurveyDomain() }
+        val rewards = surveySaveRequest.rewards.map { Reward(name = it.name, category = it.category, count = it.count) }
         val survey =
             with(surveySaveRequest) {
                 Survey(
@@ -55,11 +56,9 @@ class SurveyManagementService(
 
         val drawingBoard =
             DrawingBoard.create(
-                survey.id,
-                surveySaveRequest.targetParticipantCount,
-                surveySaveRequest.rewards.map {
-                    it.toDrawingDomain()
-                },
+                surveyId = survey.id,
+                boardSize = surveySaveRequest.targetParticipantCount,
+                rewards = rewards,
             )
         drawingBoardAdapter.save(drawingBoard)
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -8,6 +8,7 @@ import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
+import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveySaveResponse
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -64,4 +65,6 @@ class SurveyManagementService(
 
         return SurveySaveResponse(surveyId = survey.id)
     }
+
+    fun getSurveyMakeInfo(surveyId: UUID) = SurveyMakeInfoResponse.of(surveyAdapter.getSurvey(surveyId))
 }

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/BoardMakingTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/BoardMakingTest.kt
@@ -3,6 +3,7 @@ package com.sbl.sulmun2yong.drawing.domain
 import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
 import com.sbl.sulmun2yong.drawing.exception.InvalidDrawingBoardException
 import com.sbl.sulmun2yong.fixture.drawing.DrawingBoardFixtureFactory.createDrawingBoard
+import com.sbl.sulmun2yong.survey.domain.Reward
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID

--- a/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingBoardFixtureFactory.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingBoardFixtureFactory.kt
@@ -1,9 +1,9 @@
 package com.sbl.sulmun2yong.fixture.drawing
 
 import com.sbl.sulmun2yong.drawing.domain.DrawingBoard
-import com.sbl.sulmun2yong.drawing.domain.Reward
 import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
 import com.sbl.sulmun2yong.drawing.exception.InvalidDrawingBoardException
+import com.sbl.sulmun2yong.survey.domain.Reward
 import java.util.UUID
 
 object DrawingBoardFixtureFactory {

--- a/src/test/kotlin/com/sbl/sulmun2yong/fixture/survey/SurveyFixtureFactory.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/fixture/survey/SurveyFixtureFactory.kt
@@ -22,9 +22,9 @@ object SurveyFixtureFactory {
     const val TARGET_PARTICIPANT_COUNT = 100
     val REWARDS =
         listOf(
-            Reward(UUID.randomUUID(), "아메리카노", "커피", 3),
-            Reward(UUID.randomUUID(), "카페라떼", "커피", 2),
-            Reward(UUID.randomUUID(), "햄버거", "음식", 4),
+            Reward("아메리카노", "커피", 3),
+            Reward("카페라떼", "커피", 2),
+            Reward("햄버거", "음식", 4),
         )
     val SECTIONS =
         let {

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/RewardTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/RewardTest.kt
@@ -3,23 +3,20 @@ package com.sbl.sulmun2yong.survey.domain
 import com.sbl.sulmun2yong.survey.exception.InvalidRewardException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.util.UUID
 import kotlin.test.assertEquals
 
 class RewardTest {
     @Test
     fun `리워드를 생성하면 정보가 올바르게 설정된다`() {
         // given
-        val id = UUID.randomUUID()
         val name = "품목 명"
         val category = "리워드 카테고리"
         val count = 1
 
         // when
-        val reward = Reward(id = id, name = name, category = category, count = count)
+        val reward = Reward(name = name, category = category, count = count)
 
         // then
-        assertEquals(id, reward.id)
         assertEquals(name, reward.name)
         assertEquals(category, reward.category)
         assertEquals(count, reward.count)
@@ -29,7 +26,6 @@ class RewardTest {
     fun `리워드의 개수는 1이상이다`() {
         assertThrows<InvalidRewardException> {
             Reward(
-                id = UUID.randomUUID(),
                 name = "품목 명",
                 category = "리워드 카테고리",
                 count = 0,
@@ -37,7 +33,6 @@ class RewardTest {
         }
         assertThrows<InvalidRewardException> {
             Reward(
-                id = UUID.randomUUID(),
                 name = "품목 명",
                 category = "리워드 카테고리",
                 count = -1,


### PR DESCRIPTION
## 📢 설명
- 설문 제작 정보 API 구현(Notion 참고)
- 추첨 도메인의 Reward 클래스를 제거, 설문 도메인의 Reward 클래스를 사용하도록 리팩토링
- 임시용 설문 저장 API의 RequestBody에 surveyId제거
- 설문 제작 관련 API의 Security API 경로 패턴 오류 수정=

## ✅ 체크 리스트
- [x] 설문 제작 정보 API가 잘 작동하는지 확인
