### PR TITLE
[SBL-80] 설문 저장 API 구현, 설문 제작 정보 조회 및 저장 시 makerId 검사 추가

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
@@ -12,7 +12,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
-import org.springframework.http.HttpStatus
 import org.springframework.security.config.Customizer
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -23,9 +22,10 @@ import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.provisioning.InMemoryUserDetailsManager
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.web.filter.ForwardedHeaderFilter
+import org.springframework.security.web.access.AccessDeniedHandler
 
 @Configuration
 class SecurityConfig(
@@ -35,6 +35,8 @@ class SecurityConfig(
     private val username: String?,
     @Value("\${swagger.password}")
     private val password: String?,
+    private val entryPoint: AuthenticationEntryPoint,
+    private val deniedHandler: AccessDeniedHandler,
 ) {
     @Bean
     fun sessionRegistry(): SessionRegistry = SessionRegistryImpl()
@@ -103,7 +105,8 @@ class SecurityConfig(
                 authorize("/**", permitAll)
             }
             exceptionHandling {
-                authenticationEntryPoint = HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)
+                authenticationEntryPoint = entryPoint
+                accessDeniedHandler = deniedHandler
             }
             sessionManagement {
                 invalidSessionStrategy = CustomInvalidSessionStrategy()

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
@@ -24,8 +24,8 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.provisioning.InMemoryUserDetailsManager
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.web.filter.ForwardedHeaderFilter
 import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.web.filter.ForwardedHeaderFilter
 
 @Configuration
 class SecurityConfig(

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
@@ -66,9 +66,9 @@ class SecurityConfig(
             .authorizeHttpRequests { requests ->
                 requests
                     .requestMatchers("/swagger-ui/**")
-                    .hasRole("SWAGGER_USER")
+                    .hasAnyRole("SWAGGER_USER", "ADMIN")
                     .requestMatchers("/v3/api-docs/**")
-                    .hasRole("SWAGGER_USER")
+                    .hasAnyRole("SWAGGER_USER", "ADMIN")
                     .requestMatchers("/**")
                     .permitAll()
             }.formLogin(Customizer.withDefaults())

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/CustomAccessDeniedHandler.kt
@@ -1,0 +1,23 @@
+package com.sbl.sulmun2yong.global.error
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+@Component
+class CustomAccessDeniedHandler(
+    @Qualifier("handlerExceptionResolver")
+    private val resolver: HandlerExceptionResolver,
+) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException,
+    ) {
+        resolver.resolveException(request, response, null, accessDeniedException)
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,23 @@
+package com.sbl.sulmun2yong.global.error
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+@Component
+class CustomAuthenticationEntryPoint(
+    @Qualifier("handlerExceptionResolver")
+    private val resolver: HandlerExceptionResolver,
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        resolver.resolveException(request, response, null, authException)
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -11,6 +11,7 @@ enum class ErrorCode(
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GL0001", "서버 오류가 발생했습니다."),
     INPUT_INVALID_VALUE(HttpStatus.BAD_REQUEST, "GL0002", "잘못된 입력입니다."),
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "GL0003", "로그인이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "GL0004", "접근 권한이 없습니다."),
 
     // Survey (SV)
     SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "SV0002", "설문을 찾을 수 없습니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -25,6 +25,7 @@ enum class ErrorCode(
     INVALID_SECTION_IDS(HttpStatus.BAD_REQUEST, "SV0013", "유효하지 않은 섹션 ID입니다."),
     SURVEY_CLOSED(HttpStatus.BAD_REQUEST, "SV0014", "이미 마감된 설문입니다."),
     INVALID_UPDATE_SURVEY(HttpStatus.BAD_REQUEST, "SV0015", "설문 정보 갱신에 실패했습니다."),
+    INVALID_SURVEY_ACCESS(HttpStatus.FORBIDDEN, "SV0016", "설문 접근 권한이 없습니다."),
 
     // Drawing (DR)
     INVALID_DRAWING_BOARD(HttpStatus.BAD_REQUEST, "DR0001", "유효하지 않은 추첨 보드입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -24,6 +24,7 @@ enum class ErrorCode(
     INVALID_PARTICIPANT(HttpStatus.BAD_REQUEST, "SV0012", "유효하지 않은 참여자입니다."),
     INVALID_SECTION_IDS(HttpStatus.BAD_REQUEST, "SV0013", "유효하지 않은 섹션 ID입니다."),
     SURVEY_CLOSED(HttpStatus.BAD_REQUEST, "SV0014", "이미 마감된 설문입니다."),
+    INVALID_UPDATE_SURVEY(HttpStatus.BAD_REQUEST, "SV0015", "설문 정보 갱신에 실패했습니다."),
 
     // Drawing (DR)
     INVALID_DRAWING_BOARD(HttpStatus.BAD_REQUEST, "DR0001", "유효하지 않은 추첨 보드입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/GlobalExceptionHandler.kt
@@ -1,6 +1,9 @@
 package com.sbl.sulmun2yong.global.error
 
+import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.AuthenticationException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -19,6 +22,26 @@ class GlobalExceptionHandler {
     protected fun handleRuntimeException(e: BusinessException): ErrorResponse {
         log.warn(e.message, e)
         return ErrorResponse.of(e.errorCode)
+    }
+
+    @ExceptionHandler(AuthenticationException::class)
+    protected fun handleAuthenticationException(
+        e: AuthenticationException,
+        request: HttpServletRequest,
+    ): ErrorResponse {
+        val errorCode = ErrorCode.LOGIN_REQUIRED
+        log.warn("[${request.method}] ${request.requestURI}: ${errorCode.message}")
+        return ErrorResponse.of(errorCode)
+    }
+
+    @ExceptionHandler(AccessDeniedException::class)
+    protected fun handleAccessDeniedException(
+        e: AccessDeniedException,
+        request: HttpServletRequest,
+    ): ErrorResponse {
+        val errorCode = ErrorCode.ACCESS_DENIED
+        log.warn("[${request.method}] ${request.requestURI}: ${errorCode.message}")
+        return ErrorResponse.of(errorCode)
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -40,5 +40,6 @@ class SurveyManagementController(
     @GetMapping("/{surveyId}")
     override fun getSurveyMakeInfo(
         @PathVariable("surveyId") surveyId: UUID,
-    ) = ResponseEntity.ok(surveyManagementService.getSurveyMakeInfo(surveyId))
+        @LoginUser id: UUID,
+    ) = ResponseEntity.ok(surveyManagementService.getSurveyMakeInfo(surveyId = surveyId, makerId = id))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -24,7 +24,6 @@ class SurveyManagementController(
         @LoginUser id: UUID,
     ) = ResponseEntity.ok(surveyManagementService.createSurvey(makerId = id))
 
-    // TODO: 수정할 수 있는 설문의 정보에 제한이 필요
     @PutMapping("/{surveyId}")
     override fun saveSurvey(
         @PathVariable("surveyId") surveyId: UUID,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -4,7 +4,6 @@ import com.sbl.sulmun2yong.global.annotation.LoginUser
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
-import com.sbl.sulmun2yong.survey.dto.response.SurveySaveResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
@@ -29,7 +28,7 @@ interface SurveyManagementApiDoc {
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
         @RequestBody surveySaveRequest: SurveySaveRequest,
-    ): ResponseEntity<SurveySaveResponse>
+    ): ResponseEntity<Unit>
 
     @Operation(summary = "설문 제작 정보 API")
     @GetMapping("/{surveyId}")

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -34,5 +34,6 @@ interface SurveyManagementApiDoc {
     @GetMapping("/{surveyId}")
     fun getSurveyMakeInfo(
         @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
     ): ResponseEntity<SurveyMakeInfoResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -23,7 +23,6 @@ interface SurveyManagementApiDoc {
         @LoginUser id: UUID,
     ): ResponseEntity<SurveyCreateResponse>
 
-    // TODO: 추후 수정이 필요
     @Operation(summary = "설문 저장 API")
     @PutMapping("/save/{surveyId}")
     fun saveSurvey(

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -6,6 +6,7 @@ import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyResponseException
+import com.sbl.sulmun2yong.survey.exception.InvalidUpdateSurveyException
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.util.Date
@@ -87,6 +88,34 @@ data class Survey(
         // 모든 응답을 확인한 뒤 예상 섹션 ID가 종료 섹션 ID인지 확인
         require(expectedSectionId is SectionId.End) { throw InvalidSurveyResponseException() }
     }
+
+    /** 받은 값으로 수정한 설문을 반환하는 메서드 */
+    fun updateContent(
+        title: String,
+        description: String,
+        thumbnail: String?,
+        finishedAt: Date,
+        finishMessage: String,
+        targetParticipantCount: Int,
+        makerId: UUID,
+        rewards: List<Reward>,
+        sections: List<Section>,
+    ): Survey {
+        if (canNotUpdate(makerId)) throw InvalidUpdateSurveyException()
+        return copy(
+            title = title,
+            description = description,
+            thumbnail = thumbnail,
+            finishedAt = finishedAt,
+            finishMessage = finishMessage,
+            targetParticipantCount = targetParticipantCount,
+            rewards = rewards,
+            sections = sections,
+        )
+    }
+
+    /** 설문의 정보를 업데이트할 수 있는 상태인지 확인하는 메서드 */
+    private fun canNotUpdate(makerId: UUID) = makerId != this.makerId || status == SurveyStatus.IN_PROGRESS || status == SurveyStatus.CLOSED
 
     fun finish() = copy(status = SurveyStatus.CLOSED)
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -100,7 +100,14 @@ data class Survey(
         rewards: List<Reward>,
         sections: List<Section>,
     ): Survey {
-        if (canNotUpdate()) throw InvalidUpdateSurveyException()
+        // 설문이 시작 전 상태이거나, 수정 중이면서 리워드 관련 정보가 변경되지 않아야한다.
+        require(
+            status == SurveyStatus.NOT_STARTED ||
+                status == SurveyStatus.IN_MODIFICATION &&
+                isRewardInfoEquals(targetParticipantCount, rewards),
+        ) {
+            throw InvalidUpdateSurveyException()
+        }
         return copy(
             title = title,
             description = description,
@@ -113,8 +120,11 @@ data class Survey(
         )
     }
 
-    /** 설문의 정보를 업데이트할 수 있는 상태인지 확인하는 메서드 */
-    private fun canNotUpdate() = status == SurveyStatus.IN_PROGRESS || status == SurveyStatus.CLOSED
+    /** 리워드 관련 정보가 같은지 확인하는 메서드 */
+    private fun isRewardInfoEquals(
+        targetParticipantCount: Int,
+        rewards: List<Reward>,
+    ) = targetParticipantCount == this.targetParticipantCount && rewards == this.rewards
 
     fun finish() = copy(status = SurveyStatus.CLOSED)
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -97,11 +97,10 @@ data class Survey(
         finishedAt: Date,
         finishMessage: String,
         targetParticipantCount: Int,
-        makerId: UUID,
         rewards: List<Reward>,
         sections: List<Section>,
     ): Survey {
-        if (canNotUpdate(makerId)) throw InvalidUpdateSurveyException()
+        if (canNotUpdate()) throw InvalidUpdateSurveyException()
         return copy(
             title = title,
             description = description,
@@ -115,7 +114,7 @@ data class Survey(
     }
 
     /** 설문의 정보를 업데이트할 수 있는 상태인지 확인하는 메서드 */
-    private fun canNotUpdate(makerId: UUID) = makerId != this.makerId || status == SurveyStatus.IN_PROGRESS || status == SurveyStatus.CLOSED
+    private fun canNotUpdate() = status == SurveyStatus.IN_PROGRESS || status == SurveyStatus.CLOSED
 
     fun finish() = copy(status = SurveyStatus.CLOSED)
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
@@ -1,6 +1,5 @@
 package com.sbl.sulmun2yong.survey.dto.request
 
-import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import com.sbl.sulmun2yong.survey.domain.question.QuestionType
 import com.sbl.sulmun2yong.survey.domain.question.choice.Choice
 import com.sbl.sulmun2yong.survey.domain.question.choice.Choices
@@ -20,9 +19,7 @@ data class SurveySaveRequest(
     val description: String,
     // TODO: 섬네일의 URL이 우리 서비스의 S3 URL인지 확인하기
     val thumbnail: String?,
-    val publishedAt: Date?,
     val finishedAt: Date,
-    val status: SurveyStatus,
     val finishMessage: String,
     val targetParticipantCount: Int,
     val rewards: List<RewardCreateRequest>,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveySaveResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveySaveResponse.kt
@@ -1,7 +1,0 @@
-package com.sbl.sulmun2yong.survey.dto.response
-
-import java.util.UUID
-
-data class SurveySaveResponse(
-    val surveyId: UUID,
-)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidSurveyAccessException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidSurveyAccessException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.survey.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidSurveyAccessException : BusinessException(ErrorCode.INVALID_SURVEY_ACCESS)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidUpdateSurveyException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidUpdateSurveyException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.survey.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidUpdateSurveyException : BusinessException(ErrorCode.INVALID_UPDATE_SURVEY)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -1,7 +1,6 @@
 package com.sbl.sulmun2yong.survey.service
 
 import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
-import com.sbl.sulmun2yong.drawing.domain.DrawingBoard
 import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
 import com.sbl.sulmun2yong.survey.domain.Reward
 import com.sbl.sulmun2yong.survey.domain.Survey
@@ -26,41 +25,38 @@ class SurveyManagementService(
         return SurveyCreateResponse(surveyId = survey.id)
     }
 
-    // TODO: 수정할 수 있는 설문의 정보에 제한이 필요
-    // TODO: 추첨 보드 생성 로직을 startSurvey로 옮기기
     fun saveSurvey(
         surveyId: UUID,
         surveySaveRequest: SurveySaveRequest,
         makerId: UUID,
     ): SurveySaveResponse? {
-        val sectionIds = SectionIds.from(surveySaveRequest.sections.map { SectionId.Standard(it.id) })
+        val survey = surveyAdapter.getSurvey(surveyId)
         val rewards = surveySaveRequest.rewards.map { Reward(name = it.name, category = it.category, count = it.count) }
-        val survey =
+        val newSurvey =
             with(surveySaveRequest) {
-                Survey(
-                    id = surveyId,
+                val sectionIds = SectionIds.from(surveySaveRequest.sections.map { SectionId.Standard(it.id) })
+                survey.updateContent(
                     title = this.title,
                     description = this.description,
                     thumbnail = this.thumbnail,
-                    publishedAt = this.publishedAt,
                     finishedAt = this.finishedAt,
-                    status = this.status,
                     finishMessage = this.finishMessage,
-                    targetParticipantCount = surveySaveRequest.targetParticipantCount,
+                    targetParticipantCount = this.targetParticipantCount,
                     makerId = makerId,
                     rewards = rewards,
                     sections = this.sections.map { it.toDomain(sectionIds) },
                 )
             }
-        surveyAdapter.save(survey)
+        surveyAdapter.save(newSurvey)
 
-        val drawingBoard =
-            DrawingBoard.create(
-                surveyId = survey.id,
-                boardSize = surveySaveRequest.targetParticipantCount,
-                rewards = rewards,
-            )
-        drawingBoardAdapter.save(drawingBoard)
+        // TODO: 추첨 보드 생성 로직을 startSurvey로 옮기기
+        // val drawingBoard =
+        //     DrawingBoard.create(
+        //         surveyId = survey.id,
+        //         boardSize = surveySaveRequest.targetParticipantCount,
+        //         rewards = rewards,
+        //     )
+        // drawingBoardAdapter.save(drawingBoard)
 
         return SurveySaveResponse(surveyId = survey.id)
     }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -9,7 +9,7 @@ import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
-import com.sbl.sulmun2yong.survey.exception.InvalidUpdateSurveyException
+import com.sbl.sulmun2yong.survey.exception.InvalidSurveyAccessException
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -32,7 +32,7 @@ class SurveyManagementService(
     ) {
         val survey = surveyAdapter.getSurvey(surveyId)
         // 현재 유저와 설문 제작자가 다를 경우 예외 발생
-        if (survey.makerId != makerId) throw InvalidUpdateSurveyException()
+        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
         val rewards = surveySaveRequest.rewards.map { Reward(name = it.name, category = it.category, count = it.count) }
         val newSurvey =
             with(surveySaveRequest) {
@@ -66,7 +66,7 @@ class SurveyManagementService(
     ): SurveyMakeInfoResponse {
         val survey = surveyAdapter.getSurvey(surveyId)
         // 현재 유저와 설문 제작자가 다를 경우 예외 발생
-        if (survey.makerId != makerId) throw InvalidUpdateSurveyException()
+        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
         return SurveyMakeInfoResponse.of(survey)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -9,6 +9,7 @@ import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
+import com.sbl.sulmun2yong.survey.exception.InvalidUpdateSurveyException
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -30,6 +31,8 @@ class SurveyManagementService(
         makerId: UUID,
     ) {
         val survey = surveyAdapter.getSurvey(surveyId)
+        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
+        if (survey.makerId != makerId) throw InvalidUpdateSurveyException()
         val rewards = surveySaveRequest.rewards.map { Reward(name = it.name, category = it.category, count = it.count) }
         val newSurvey =
             with(surveySaveRequest) {
@@ -41,7 +44,6 @@ class SurveyManagementService(
                     finishedAt = this.finishedAt,
                     finishMessage = this.finishMessage,
                     targetParticipantCount = this.targetParticipantCount,
-                    makerId = makerId,
                     rewards = rewards,
                     sections = this.sections.map { it.toDomain(sectionIds) },
                 )
@@ -58,5 +60,13 @@ class SurveyManagementService(
         // drawingBoardAdapter.save(drawingBoard)
     }
 
-    fun getSurveyMakeInfo(surveyId: UUID) = SurveyMakeInfoResponse.of(surveyAdapter.getSurvey(surveyId))
+    fun getSurveyMakeInfo(
+        surveyId: UUID,
+        makerId: UUID,
+    ): SurveyMakeInfoResponse {
+        val survey = surveyAdapter.getSurvey(surveyId)
+        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
+        if (survey.makerId != makerId) throw InvalidUpdateSurveyException()
+        return SurveyMakeInfoResponse.of(survey)
+    }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -9,7 +9,6 @@ import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
-import com.sbl.sulmun2yong.survey.dto.response.SurveySaveResponse
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -29,7 +28,7 @@ class SurveyManagementService(
         surveyId: UUID,
         surveySaveRequest: SurveySaveRequest,
         makerId: UUID,
-    ): SurveySaveResponse? {
+    ) {
         val survey = surveyAdapter.getSurvey(surveyId)
         val rewards = surveySaveRequest.rewards.map { Reward(name = it.name, category = it.category, count = it.count) }
         val newSurvey =
@@ -57,8 +56,6 @@ class SurveyManagementService(
         //         rewards = rewards,
         //     )
         // drawingBoardAdapter.save(drawingBoard)
-
-        return SurveySaveResponse(surveyId = survey.id)
     }
 
     fun getSurveyMakeInfo(surveyId: UUID) = SurveyMakeInfoResponse.of(surveyAdapter.getSurvey(surveyId))

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/domain/User.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/domain/User.kt
@@ -14,6 +14,7 @@ data class User(
     var phoneNumber: PhoneNumber?,
     val role: UserRole,
 ) {
+    // TODO: UserRole이 AUTHENTICATED_USER일 경우 phoneNumber는 null이 아닌지 검사
     init {
         if (nickname.length !in 2..10) {
             throw InvalidUserException()

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -259,7 +259,6 @@ class SurveyTest {
         val newThumbnail = "new thumbnail"
         val newFinishMessage = "new finish message"
         val newTargetParticipantCount = 10
-        val makerId = UUID.randomUUID()
         val newRewards = listOf(Reward("new reward", "new category", 1))
         val sectionId = SectionId.Standard(UUID.randomUUID())
         val newSections =
@@ -273,7 +272,7 @@ class SurveyTest {
                     sectionIds = SectionIds(listOf(sectionId, SectionId.End)),
                 ),
             )
-        val survey = createSurvey(makerId = makerId, status = SurveyStatus.NOT_STARTED)
+        val survey = createSurvey(status = SurveyStatus.NOT_STARTED)
 
         // when
         val newSurvey =
@@ -284,7 +283,6 @@ class SurveyTest {
                 finishedAt = survey.finishedAt,
                 finishMessage = newFinishMessage,
                 targetParticipantCount = newTargetParticipantCount,
-                makerId = makerId,
                 rewards = newRewards,
                 sections =
                     listOf(
@@ -307,19 +305,16 @@ class SurveyTest {
             assertEquals(survey.finishedAt, this.finishedAt)
             assertEquals(newFinishMessage, this.finishMessage)
             assertEquals(newTargetParticipantCount, this.targetParticipantCount)
-            assertEquals(makerId, this.makerId)
             assertEquals(newRewards, this.rewards)
             assertEquals(newSections, this.sections)
         }
     }
 
     @Test
-    fun `설문이 진행 중이거나 종료된 상태거나 현재 유저의 ID와 makerId가 다르면 내용를 업데이트할 수 있다`() {
+    fun `설문이 진행 중이거나 종료된 상태면 내용를 업데이트할 수 없다`() {
         // given
-        val makerId = UUID.randomUUID()
-        val survey1 = createSurvey(status = SurveyStatus.IN_PROGRESS, makerId = makerId)
-        val survey2 = createSurvey(status = SurveyStatus.CLOSED, makerId = makerId)
-        val survey3 = createSurvey(status = SurveyStatus.NOT_STARTED)
+        val survey1 = createSurvey(status = SurveyStatus.IN_PROGRESS)
+        val survey2 = createSurvey(status = SurveyStatus.CLOSED)
 
         // when, then
         // 설문이 진행 중인 경우 예외 발생
@@ -331,7 +326,6 @@ class SurveyTest {
                 finishedAt = survey1.finishedAt,
                 finishMessage = survey1.finishMessage,
                 targetParticipantCount = survey1.targetParticipantCount,
-                makerId = makerId,
                 rewards = survey1.rewards,
                 sections = survey1.sections,
             )
@@ -345,23 +339,8 @@ class SurveyTest {
                 finishedAt = survey2.finishedAt,
                 finishMessage = survey2.finishMessage,
                 targetParticipantCount = survey2.targetParticipantCount,
-                makerId = makerId,
                 rewards = survey2.rewards,
                 sections = survey2.sections,
-            )
-        }
-        // makerId가 다른 경우 예외 발생
-        assertThrows<InvalidUpdateSurveyException> {
-            survey3.updateContent(
-                title = survey3.title,
-                description = survey3.description,
-                thumbnail = survey3.thumbnail,
-                finishedAt = survey3.finishedAt,
-                finishMessage = survey3.finishMessage,
-                targetParticipantCount = survey3.targetParticipantCount,
-                makerId = UUID.randomUUID(),
-                rewards = survey3.rewards,
-                sections = survey3.sections,
             )
         }
     }

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -311,10 +311,11 @@ class SurveyTest {
     }
 
     @Test
-    fun `설문이 진행 중이거나 종료된 상태면 내용를 업데이트할 수 없다`() {
+    fun `설문이 시작 전 상태이거나, 수정 중이면서 리워드 관련 정보가 변경되지 않아야 설문 정보 갱신이 가능하다`() {
         // given
         val survey1 = createSurvey(status = SurveyStatus.IN_PROGRESS)
         val survey2 = createSurvey(status = SurveyStatus.CLOSED)
+        val survey3 = createSurvey(status = SurveyStatus.IN_MODIFICATION)
 
         // when, then
         // 설문이 진행 중인 경우 예외 발생
@@ -340,6 +341,43 @@ class SurveyTest {
                 finishMessage = survey2.finishMessage,
                 targetParticipantCount = survey2.targetParticipantCount,
                 rewards = survey2.rewards,
+                sections = survey2.sections,
+            )
+        }
+        // 설문이 수정 중일 때 리워드 관련 정보가 변경된 경우 예외 발생
+        assertThrows<InvalidUpdateSurveyException> {
+            survey3.updateContent(
+                title = survey2.title,
+                description = survey2.description,
+                thumbnail = survey2.thumbnail,
+                finishedAt = survey2.finishedAt,
+                finishMessage = survey2.finishMessage,
+                targetParticipantCount = survey2.targetParticipantCount,
+                rewards = listOf(),
+                sections = survey2.sections,
+            )
+        }
+        assertThrows<InvalidUpdateSurveyException> {
+            survey3.updateContent(
+                title = survey2.title,
+                description = survey2.description,
+                thumbnail = survey2.thumbnail,
+                finishedAt = survey2.finishedAt,
+                finishMessage = survey2.finishMessage,
+                targetParticipantCount = 1000,
+                rewards = survey2.rewards,
+                sections = survey2.sections,
+            )
+        }
+        assertThrows<InvalidUpdateSurveyException> {
+            survey3.updateContent(
+                title = survey2.title,
+                description = survey2.description,
+                thumbnail = survey2.thumbnail,
+                finishedAt = survey2.finishedAt,
+                finishMessage = survey2.finishMessage,
+                targetParticipantCount = 1000,
+                rewards = listOf(),
                 sections = survey2.sections,
             )
         }

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -344,41 +344,42 @@ class SurveyTest {
                 sections = survey2.sections,
             )
         }
+        // 설문이 수정 중일 때 리워드 관련 정보가 변경되지 않은 경우 정상적으로 진행
+        assertDoesNotThrow {
+            survey3.updateContent(
+                title = survey3.title,
+                description = survey3.description,
+                thumbnail = survey3.thumbnail,
+                finishedAt = survey3.finishedAt,
+                finishMessage = survey3.finishMessage,
+                targetParticipantCount = survey3.targetParticipantCount,
+                rewards = survey3.rewards,
+                sections = survey3.sections,
+            )
+        }
         // 설문이 수정 중일 때 리워드 관련 정보가 변경된 경우 예외 발생
         assertThrows<InvalidUpdateSurveyException> {
             survey3.updateContent(
-                title = survey2.title,
-                description = survey2.description,
-                thumbnail = survey2.thumbnail,
-                finishedAt = survey2.finishedAt,
-                finishMessage = survey2.finishMessage,
-                targetParticipantCount = survey2.targetParticipantCount,
+                title = survey3.title,
+                description = survey3.description,
+                thumbnail = survey3.thumbnail,
+                finishedAt = survey3.finishedAt,
+                finishMessage = survey3.finishMessage,
+                targetParticipantCount = survey3.targetParticipantCount,
                 rewards = listOf(),
-                sections = survey2.sections,
+                sections = survey3.sections,
             )
         }
         assertThrows<InvalidUpdateSurveyException> {
             survey3.updateContent(
-                title = survey2.title,
-                description = survey2.description,
-                thumbnail = survey2.thumbnail,
-                finishedAt = survey2.finishedAt,
-                finishMessage = survey2.finishMessage,
+                title = survey3.title,
+                description = survey3.description,
+                thumbnail = survey3.thumbnail,
+                finishedAt = survey3.finishedAt,
+                finishMessage = survey3.finishMessage,
                 targetParticipantCount = 1000,
-                rewards = survey2.rewards,
-                sections = survey2.sections,
-            )
-        }
-        assertThrows<InvalidUpdateSurveyException> {
-            survey3.updateContent(
-                title = survey2.title,
-                description = survey2.description,
-                thumbnail = survey2.thumbnail,
-                finishedAt = survey2.finishedAt,
-                finishMessage = survey2.finishMessage,
-                targetParticipantCount = 1000,
-                rewards = listOf(),
-                sections = survey2.sections,
+                rewards = survey3.rewards,
+                sections = survey3.sections,
             )
         }
     }

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -15,9 +15,13 @@ import com.sbl.sulmun2yong.fixture.survey.SurveyFixtureFactory.TITLE
 import com.sbl.sulmun2yong.fixture.survey.SurveyFixtureFactory.createSurvey
 import com.sbl.sulmun2yong.survey.domain.response.SectionResponse
 import com.sbl.sulmun2yong.survey.domain.response.SurveyResponse
+import com.sbl.sulmun2yong.survey.domain.routing.RoutingStrategy
+import com.sbl.sulmun2yong.survey.domain.section.Section
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
+import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyResponseException
+import com.sbl.sulmun2yong.survey.exception.InvalidUpdateSurveyException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
@@ -245,5 +249,120 @@ class SurveyTest {
 
         // then
         assertEquals(SurveyStatus.CLOSED, finishedSurvey.status)
+    }
+
+    @Test
+    fun `설문의 내용를 업데이트할 수 있다`() {
+        // given
+        val newTitle = "new title"
+        val newDescription = "new description"
+        val newThumbnail = "new thumbnail"
+        val newFinishMessage = "new finish message"
+        val newTargetParticipantCount = 10
+        val makerId = UUID.randomUUID()
+        val newRewards = listOf(Reward("new reward", "new category", 1))
+        val sectionId = SectionId.Standard(UUID.randomUUID())
+        val newSections =
+            listOf(
+                Section(
+                    id = sectionId,
+                    title = "",
+                    description = "",
+                    routingStrategy = RoutingStrategy.NumericalOrder,
+                    questions = emptyList(),
+                    sectionIds = SectionIds(listOf(sectionId, SectionId.End)),
+                ),
+            )
+        val survey = createSurvey(makerId = makerId, status = SurveyStatus.NOT_STARTED)
+
+        // when
+        val newSurvey =
+            survey.updateContent(
+                title = newTitle,
+                description = newDescription,
+                thumbnail = newThumbnail,
+                finishedAt = survey.finishedAt,
+                finishMessage = newFinishMessage,
+                targetParticipantCount = newTargetParticipantCount,
+                makerId = makerId,
+                rewards = newRewards,
+                sections =
+                    listOf(
+                        Section(
+                            id = sectionId,
+                            title = "",
+                            description = "",
+                            routingStrategy = RoutingStrategy.NumericalOrder,
+                            questions = emptyList(),
+                            sectionIds = SectionIds.from(listOf(sectionId)),
+                        ),
+                    ),
+            )
+
+        // then
+        with(newSurvey) {
+            assertEquals(newTitle, this.title)
+            assertEquals(newDescription, this.description)
+            assertEquals(newThumbnail, this.thumbnail)
+            assertEquals(survey.finishedAt, this.finishedAt)
+            assertEquals(newFinishMessage, this.finishMessage)
+            assertEquals(newTargetParticipantCount, this.targetParticipantCount)
+            assertEquals(makerId, this.makerId)
+            assertEquals(newRewards, this.rewards)
+            assertEquals(newSections, this.sections)
+        }
+    }
+
+    @Test
+    fun `설문이 진행 중이거나 종료된 상태거나 현재 유저의 ID와 makerId가 다르면 내용를 업데이트할 수 있다`() {
+        // given
+        val makerId = UUID.randomUUID()
+        val survey1 = createSurvey(status = SurveyStatus.IN_PROGRESS, makerId = makerId)
+        val survey2 = createSurvey(status = SurveyStatus.CLOSED, makerId = makerId)
+        val survey3 = createSurvey(status = SurveyStatus.NOT_STARTED)
+
+        // when, then
+        // 설문이 진행 중인 경우 예외 발생
+        assertThrows<InvalidUpdateSurveyException> {
+            survey1.updateContent(
+                title = survey1.title,
+                description = survey1.description,
+                thumbnail = survey1.thumbnail,
+                finishedAt = survey1.finishedAt,
+                finishMessage = survey1.finishMessage,
+                targetParticipantCount = survey1.targetParticipantCount,
+                makerId = makerId,
+                rewards = survey1.rewards,
+                sections = survey1.sections,
+            )
+        }
+        // 설문이 마감된 경우 예외 발생
+        assertThrows<InvalidUpdateSurveyException> {
+            survey2.updateContent(
+                title = survey2.title,
+                description = survey2.description,
+                thumbnail = survey2.thumbnail,
+                finishedAt = survey2.finishedAt,
+                finishMessage = survey2.finishMessage,
+                targetParticipantCount = survey2.targetParticipantCount,
+                makerId = makerId,
+                rewards = survey2.rewards,
+                sections = survey2.sections,
+            )
+        }
+        // makerId가 다른 경우 예외 발생
+        assertThrows<InvalidUpdateSurveyException> {
+            survey3.updateContent(
+                title = survey3.title,
+                description = survey3.description,
+                thumbnail = survey3.thumbnail,
+                finishedAt = survey3.finishedAt,
+                finishMessage = survey3.finishMessage,
+                targetParticipantCount = survey3.targetParticipantCount,
+                makerId = UUID.randomUUID(),
+                rewards = survey3.rewards,
+                sections = survey3.sections,
+            )
+        }
     }
 }


### PR DESCRIPTION
## 📢 설명
- 설문 저장 API 구현
  - 설문의 상태가 NOT_STARTED거나, 설문의 상태가 IN_MODIFICATION이면서 리워드 관련 정보의 변화가 없을 경우만 수정이 가능
- 설문 저장, 제작 정보 조회 시 설문의 makerId와 현재 유저 ID가 같은지 검사
- 로그인 안한 상태(401) or 권한 부족 상태(403)에 기존 에러 형식에 맞는 에러 객체를 반환하도록 수정
- Swagger에 ADMIN도 접근할 수 있도록 수정

## ✅ 체크 리스트
- [x] 첫 번째 ADMIN 계정으로 로그인한 뒤 설문 생성 API 호출이 정상적으로 되는지 확인
- [x] 생성된 설문의 ID로 설문 제작 정보 조회 API 호출이 정상적으로 되는지 확인
- [x] 설문 제작 정보의 ResponseBody에서 publishedAt과 status를 제거하고, 원하는 대로 값들을 수정한 뒤 설문 저장 API 호출이 정상적으로 되는지 확인
- [x] 로그아웃 한 상태로 설문 생성 API 호출했을 때 401에러, `로그인이 필요합니다.` 메시지가 나오는지 확인
- [x] ADMIN 권한이 없는 사용자로 로그인 한 상태로 설문 생성 API 호출했을 때 403에러, `접근 권한이 없습니다.` 메시지가 나오는지 확인
- [x] 두 번째 ADMIN 계정(첫 번째와 달라야함)으로 로그인한 뒤 첫 번째 계정으로 생성한 설문 ID로 설문 제작 정보 조회 API 호출 시 403에러, `설문 접근 권한이 없습니다.` 메시지가 나오는지 확인
