### PR TITLE
[SBL-90] 배포 전 기타 수정사항 반영

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -62,6 +62,7 @@ jobs:
             MONGODB_URL: ${{ secrets.DEVELOP_MONGODB_URL }}
             MONGODB_DATABASE: ${{ secrets.DEVELOP_MONGODB_DATABASE }}
             FRONTEND_BASE_URL: http://localhost:3000
+            BACKEND_BASE_URL: http://dev.api.sulmoon.io
 
         steps:
             - name: EC2에 배포
@@ -83,5 +84,6 @@ jobs:
                         -e SPRING_DATA_MONGODB_URI=${{ env.MONGODB_URL }} \
                         -e SPRING_DATA_MONGODB_DATABASE=${{ env.MONGODB_DATABASE }} \
                         -e FRONTEND_BASE-URL=${{ env.FRONTEND_BASE_URL }} \
+                        -e BACKEND_BASE-URL=${{ env.BACKEND_BASE_URL }} \
                         ${{ secrets.DOCKER_USERNAME }}/${{ env.DOCKER_IMAGE_NAME }}
                       docker image prune -af

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -67,6 +67,7 @@ jobs:
             MONGODB_URL: ${{ secrets.PRODUCTION_MONGODB_URL }}
             MONGODB_DATABASE: ${{ secrets.PRODUCTION_MONGODB_DATABASE }}
             FRONTEND_BASE_URL: https://sulmoon.io
+            BACKEND_BASE_URL: https://api.sulmoon.io
 
         steps:
             - name: EC2에 배포
@@ -87,5 +88,6 @@ jobs:
                         -e SPRING_DATA_MONGODB_URI=${{ env.MONGODB_URL }} \
                         -e SPRING_DATA_MONGODB_DATABASE=${{ env.MONGODB_DATABASE }} \
                         -e FRONTEND_BASE-URL=${{ env.FRONTEND_BASE_URL }} \
+                        -e BACKEND_BASE-URL=${{ env.BACKEND_BASE_URL }} \
                         ${{ secrets.DOCKER_USERNAME }}/${{ env.DOCKER_IMAGE_NAME }}
                       docker image prune -af

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/annotation/IsAdmin.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/annotation/IsAdmin.kt
@@ -1,0 +1,8 @@
+package com.sbl.sulmun2yong.global.annotation
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@AuthenticationPrincipal
+annotation class IsAdmin

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/WebMvcConfig.kt
@@ -1,5 +1,6 @@
 package com.sbl.sulmun2yong.global.config
 
+import com.sbl.sulmun2yong.global.resolver.IsAdminArgumentResolver
 import com.sbl.sulmun2yong.global.resolver.LoginUserArgumentResolver
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
@@ -12,6 +13,7 @@ class WebMvcConfig(
     @Value("\${frontend.base-url}")
     private val baseUrl: String,
     private val loginUserArgumentResolver: LoginUserArgumentResolver,
+    private val isAdminArgumentResolver: IsAdminArgumentResolver,
 ) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry
@@ -24,5 +26,6 @@ class WebMvcConfig(
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(loginUserArgumentResolver)
+        resolvers.add(isAdminArgumentResolver)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/resolver/IsAdminArgumentResolver.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/resolver/IsAdminArgumentResolver.kt
@@ -1,0 +1,34 @@
+package com.sbl.sulmun2yong.global.resolver
+
+import com.sbl.sulmun2yong.global.annotation.IsAdmin
+import com.sbl.sulmun2yong.global.config.oauth2.CustomOAuth2User
+import com.sbl.sulmun2yong.user.domain.UserRole
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class IsAdminArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        val hasIsAdminAnnotation = parameter.getParameterAnnotation(IsAdmin::class.java) != null
+        val isBoolean = Boolean::class.java.isAssignableFrom(parameter.parameterType)
+        return hasIsAdminAnnotation && isBoolean
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Any? {
+        val customOAuth2User = SecurityContextHolder.getContext().authentication.principal
+        if (customOAuth2User is CustomOAuth2User) {
+            return customOAuth2User.getAuthorities().any { it.authority == UserRole.ROLE_ADMIN.name }
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResponseController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResponseController.kt
@@ -1,5 +1,6 @@
 package com.sbl.sulmun2yong.survey.controller
 
+import com.sbl.sulmun2yong.global.annotation.IsAdmin
 import com.sbl.sulmun2yong.survey.controller.doc.SurveyResponseApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
@@ -14,13 +15,16 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/surveys/response")
-class SurveyResponseController(private val surveyResponseService: SurveyResponseService) : SurveyResponseApiDoc {
+class SurveyResponseController(
+    private val surveyResponseService: SurveyResponseService,
+) : SurveyResponseApiDoc {
     @PostMapping("/{survey-id}")
     override fun responseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,
         @RequestBody surveyResponseRequest: SurveyResponseRequest,
+        @IsAdmin isAdmin: Boolean,
     ): ResponseEntity<SurveyParticipantResponse> =
         ResponseEntity.ok(
-            surveyResponseService.responseToSurvey(surveyId, surveyResponseRequest),
+            surveyResponseService.responseToSurvey(surveyId, surveyResponseRequest, isAdmin),
         )
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResponseController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResponseController.kt
@@ -5,6 +5,7 @@ import com.sbl.sulmun2yong.survey.controller.doc.SurveyResponseApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
 import com.sbl.sulmun2yong.survey.service.SurveyResponseService
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -21,7 +22,7 @@ class SurveyResponseController(
     @PostMapping("/{survey-id}")
     override fun responseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,
-        @RequestBody surveyResponseRequest: SurveyResponseRequest,
+        @Valid @RequestBody surveyResponseRequest: SurveyResponseRequest,
         @IsAdmin isAdmin: Boolean,
     ): ResponseEntity<SurveyParticipantResponse> =
         ResponseEntity.ok(

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResponseApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResponseApiDoc.kt
@@ -5,6 +5,7 @@ import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -17,7 +18,7 @@ interface SurveyResponseApiDoc {
     @PostMapping
     fun responseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,
-        @RequestBody surveyResponseRequest: SurveyResponseRequest,
+        @Valid @RequestBody surveyResponseRequest: SurveyResponseRequest,
         @IsAdmin isAdmin: Boolean,
     ): ResponseEntity<SurveyParticipantResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResponseApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResponseApiDoc.kt
@@ -1,5 +1,6 @@
 package com.sbl.sulmun2yong.survey.controller.doc
 
+import com.sbl.sulmun2yong.global.annotation.IsAdmin
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -17,5 +18,6 @@ interface SurveyResponseApiDoc {
     fun responseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,
         @RequestBody surveyResponseRequest: SurveyResponseRequest,
+        @IsAdmin isAdmin: Boolean,
     ): ResponseEntity<SurveyParticipantResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveyResponseRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveyResponseRequest.kt
@@ -5,21 +5,28 @@ import com.sbl.sulmun2yong.survey.domain.response.ResponseDetail
 import com.sbl.sulmun2yong.survey.domain.response.SectionResponse
 import com.sbl.sulmun2yong.survey.domain.response.SurveyResponse
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Size
 import java.util.UUID
 
 data class SurveyResponseRequest(
+    @field:Valid
     val sectionResponses: List<SectionResponseRequest>,
+    @field:Size(max = 100, message = "visitorId는 최대 100자까지 입력 가능합니다.")
     val visitorId: String,
 ) {
     data class SectionResponseRequest(
         val sectionId: UUID,
-        val questionResponses: List<QuestionResponseRequest>,
+        @field:Valid
+        val questionResponses: List<@Valid QuestionResponseRequest>,
     ) {
         data class QuestionResponseRequest(
             val questionId: UUID,
-            val responses: List<ResponseDetailRequest>,
+            @field:Valid
+            val responses: List<@Valid ResponseDetailRequest>,
         ) {
             data class ResponseDetailRequest(
+                @field:Size(max = 1000, message = "내용은 최대 1000자까지 입력 가능합니다.")
                 val content: String,
                 val isOther: Boolean,
             ) {

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResponseService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResponseService.kt
@@ -24,12 +24,14 @@ class SurveyResponseService(
     fun responseToSurvey(
         surveyId: UUID,
         surveyResponseRequest: SurveyResponseRequest,
+        isAdmin: Boolean,
     ): SurveyParticipantResponse {
         val visitorId = surveyResponseRequest.visitorId
-
-        // 이미 참여한 설문인지 검증
-        validateIsAlreadyParticipated(surveyId, visitorId)
-        fingerprintApi.validateVisitorId(visitorId)
+        // 이미 참여한 설문인지 검증(Admin인 경우 스킵)
+        if (!isAdmin) {
+            validateIsAlreadyParticipated(surveyId, visitorId)
+            fingerprintApi.validateVisitorId(visitorId)
+        }
 
         val survey = surveyAdapter.getSurvey(surveyId)
         if (survey.status == SurveyStatus.CLOSED) {


### PR DESCRIPTION
## 📢 설명
- 설문 응답 DTO에 대한 validation 추가(content 1000자 이하, visitorId 100자 이하)
- admin여부를 얻을 수 있는 IsAdmin 어노테이션 구현
- 설문 응답 시 admin이면 중복 응답이 가능하도록 수정
- dev, prod 서버 swagger url 수정

## ✅ 체크 리스트
- [x] 설문 응답 시 content를 1000자 초과로 보내거나, visitorId를 100자 초과로 보낼 시 예외가 발생하는지 확인
- [x] admin이 아닌 상태로 설문 중복 참여 시 예외가 발생하는지 확인
- [x] admin인 상태로 설문 중복 참여 시 예외가 발생 안하는지 확인
