### PR TITLE
[SBL-81] 설문 시작 API 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -28,6 +28,7 @@ enum class ErrorCode(
     INVALID_UPDATE_SURVEY(HttpStatus.BAD_REQUEST, "SV0015", "설문 정보 갱신에 실패했습니다."),
     INVALID_SURVEY_ACCESS(HttpStatus.FORBIDDEN, "SV0016", "설문 접근 권한이 없습니다."),
     ALREADY_PARTICIPATED(HttpStatus.BAD_REQUEST, "SV0017", "이미 참여한 설문입니다."),
+    INVALID_SURVEY_START(HttpStatus.BAD_REQUEST, "SV0018", "설문 시작에 실패했습니다."),
 
     // Drawing (DR)
     INVALID_DRAWING_BOARD(HttpStatus.BAD_REQUEST, "DR0001", "유효하지 않은 추첨 보드입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/DateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/DateUtil.kt
@@ -1,0 +1,31 @@
+package com.sbl.sulmun2yong.global.util
+
+import java.util.Calendar
+import java.util.Date
+
+object DateUtil {
+    /** 현재 시간 (기본: 초 단위 이하 제거) */
+    fun getCurrentDate(
+        noMin: Boolean = false,
+        noSec: Boolean = true,
+        noMilliSecond: Boolean = true,
+    ): Date {
+        val calendar = Calendar.getInstance()
+        calendar.time = Date()
+        if (noMin) calendar.set(Calendar.MINUTE, 0)
+        if (noSec) calendar.set(Calendar.SECOND, 0)
+        if (noMilliSecond) calendar.set(Calendar.MILLISECOND, 0)
+        return calendar.time
+    }
+
+    /** {day} 뒤의 Date를 가져온다. (기본: 초 단위 이하 제거, 현재 날짜의 60일 뒤) */
+    fun getDateAfterDay(
+        date: Date = getCurrentDate(),
+        day: Int = 60,
+    ): Date {
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        calendar.add(Calendar.DATE, day)
+        return calendar.time
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -1,11 +1,13 @@
 package com.sbl.sulmun2yong.survey.controller
 
+import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
 import com.sbl.sulmun2yong.global.annotation.LoginUser
 import com.sbl.sulmun2yong.survey.controller.doc.SurveyManagementApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.service.SurveyManagementService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -18,6 +20,7 @@ import java.util.UUID
 @RequestMapping("/api/v1/surveys/workbench")
 class SurveyManagementController(
     private val surveyManagementService: SurveyManagementService,
+    private val drawingBoardAdapter: DrawingBoardAdapter,
 ) : SurveyManagementApiDoc {
     @PostMapping("/create")
     override fun createSurvey(
@@ -42,4 +45,10 @@ class SurveyManagementController(
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ) = ResponseEntity.ok(surveyManagementService.getSurveyMakeInfo(surveyId = surveyId, makerId = id))
+
+    @PatchMapping("/start/{surveyId}")
+    override fun startSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ) = ResponseEntity.ok(surveyManagementService.startSurvey(surveyId = surveyId, makerId = id))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -36,4 +37,11 @@ interface SurveyManagementApiDoc {
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ): ResponseEntity<SurveyMakeInfoResponse>
+
+    @Operation(summary = "설문 시작 API")
+    @PatchMapping("/start/{surveyId}")
+    fun startSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Reward.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Reward.kt
@@ -10,4 +10,17 @@ data class Reward(
     init {
         require(count > 0) { throw InvalidRewardException() }
     }
+
+    companion object {
+        const val DEFAULT_REWARD_NAME = "리워드 명"
+        const val DEFAULT_REWARD_CATEGORY = "리워드 카테고리"
+        const val DEFAULT_REWARD_COUNT = 1
+
+        fun create() =
+            Reward(
+                name = DEFAULT_REWARD_NAME,
+                category = DEFAULT_REWARD_CATEGORY,
+                count = DEFAULT_REWARD_COUNT,
+            )
+    }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -35,6 +35,8 @@ data class Survey(
         require(isSurveyStatusValid()) { throw InvalidSurveyException() }
         require(isFinishedAtAfterPublishedAt()) { throw InvalidSurveyException() }
         require(isTargetParticipantsEnough()) { throw InvalidSurveyException() }
+        // TODO: 추후에 리워드가 없는 설문도 생성할 수 있도록 수정하기
+        require(rewards.isNotEmpty()) { throw InvalidSurveyException() }
         require(isSectionIdsValid()) { throw InvalidSurveyException() }
     }
 
@@ -58,7 +60,7 @@ data class Survey(
                 finishMessage = DEFAULT_FINISH_MESSAGE,
                 targetParticipantCount = DEFAULT_TARGET_PARTICIPANT_COUNT,
                 makerId = makerId,
-                rewards = emptyList(),
+                rewards = listOf(Reward.create()),
                 sections = listOf(Section.create()),
             )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -1,11 +1,13 @@
 package com.sbl.sulmun2yong.survey.domain
 
+import com.sbl.sulmun2yong.global.util.DateUtil
 import com.sbl.sulmun2yong.survey.domain.response.SurveyResponse
 import com.sbl.sulmun2yong.survey.domain.section.Section
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyResponseException
+import com.sbl.sulmun2yong.survey.exception.InvalidSurveyStartException
 import com.sbl.sulmun2yong.survey.exception.InvalidUpdateSurveyException
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -127,6 +129,11 @@ data class Survey(
     ) = targetParticipantCount == this.targetParticipantCount && rewards == this.rewards
 
     fun finish() = copy(status = SurveyStatus.CLOSED)
+
+    fun start(): Survey {
+        require(status == SurveyStatus.NOT_STARTED) { throw InvalidSurveyStartException() }
+        return copy(status = SurveyStatus.IN_PROGRESS, publishedAt = DateUtil.getCurrentDate())
+    }
 
     fun getRewardCount() = rewards.sumOf { it.count }
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidSurveyStartException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidSurveyStartException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.survey.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidSurveyStartException : BusinessException(ErrorCode.INVALID_SURVEY_START)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -1,6 +1,7 @@
 package com.sbl.sulmun2yong.survey.service
 
 import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
+import com.sbl.sulmun2yong.drawing.domain.DrawingBoard
 import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
 import com.sbl.sulmun2yong.survey.domain.Reward
 import com.sbl.sulmun2yong.survey.domain.Survey
@@ -51,13 +52,6 @@ class SurveyManagementService(
         surveyAdapter.save(newSurvey)
 
         // TODO: 추첨 보드 생성 로직을 startSurvey로 옮기기
-        // val drawingBoard =
-        //     DrawingBoard.create(
-        //         surveyId = survey.id,
-        //         boardSize = surveySaveRequest.targetParticipantCount,
-        //         rewards = rewards,
-        //     )
-        // drawingBoardAdapter.save(drawingBoard)
     }
 
     fun getSurveyMakeInfo(
@@ -68,5 +62,23 @@ class SurveyManagementService(
         // 현재 유저와 설문 제작자가 다를 경우 예외 발생
         if (survey.makerId != makerId) throw InvalidSurveyAccessException()
         return SurveyMakeInfoResponse.of(survey)
+    }
+
+    // TODO: 트랜잭션 적용 필요
+    fun startSurvey(
+        surveyId: UUID,
+        makerId: UUID,
+    ) {
+        val survey = surveyAdapter.getSurvey(surveyId)
+        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
+        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
+        surveyAdapter.save(survey.start())
+        val drawingBoard =
+            DrawingBoard.create(
+                surveyId = survey.id,
+                boardSize = survey.targetParticipantCount,
+                rewards = survey.rewards,
+            )
+        drawingBoardAdapter.save(drawingBoard)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -50,8 +50,6 @@ class SurveyManagementService(
                 )
             }
         surveyAdapter.save(newSurvey)
-
-        // TODO: 추첨 보드 생성 로직을 startSurvey로 옮기기
     }
 
     fun getSurveyMakeInfo(

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/domain/DrawingTest.kt
@@ -15,7 +15,7 @@ class DrawingTest {
     @Test
     fun `꽝 티켓을을 뽑으면 DrawingResultNonWinner 도메인이 만들어지고  DrawingBoard 에 그 결과가 반영된다`() {
         // given
-        val drawingBoard = DrawingBoardFixtureFactory.createDrawingBoard()
+        val drawingBoard = DrawingBoardFixtureFactory.createDrawingBoardRewardNotExistsIndex3()
 
         // when
         val drawingResult = drawingBoard.getDrawingResult(3)

--- a/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingBoardFixtureFactory.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingBoardFixtureFactory.kt
@@ -72,7 +72,7 @@ object DrawingBoardFixtureFactory {
             rewards = emptyList(),
         )
 
-    // 3번에 꽝 티켓이 없는 티켓 리스트 만들기
+    // 3번에 꽝 티켓이 있는 티켓 리스트 만들기
     private fun createTicketsRewardNotExistsIndex3(
         rewards: List<Reward>,
         maxTicketCount: Int,

--- a/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingBoardFixtureFactory.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/fixture/drawing/DrawingBoardFixtureFactory.kt
@@ -72,7 +72,7 @@ object DrawingBoardFixtureFactory {
             rewards = emptyList(),
         )
 
-    // 3번에 꽝 티켓이 있는 티켓 리스트 만들기
+    // 3번에 꽝 티켓이 없는 티켓 리스트 만들기
     private fun createTicketsRewardNotExistsIndex3(
         rewards: List<Reward>,
         maxTicketCount: Int,

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/RewardTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/RewardTest.kt
@@ -15,11 +15,19 @@ class RewardTest {
 
         // when
         val reward = Reward(name = name, category = category, count = count)
+        val defaultReward = Reward.create()
 
         // then
-        assertEquals(name, reward.name)
-        assertEquals(category, reward.category)
-        assertEquals(count, reward.count)
+        with(reward) {
+            assertEquals(name, this.name)
+            assertEquals(category, this.category)
+            assertEquals(count, this.count)
+        }
+        with(defaultReward) {
+            assertEquals(Reward.DEFAULT_REWARD_NAME, this.name)
+            assertEquals(Reward.DEFAULT_REWARD_CATEGORY, this.category)
+            assertEquals(Reward.DEFAULT_REWARD_COUNT, this.count)
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -13,6 +13,7 @@ import com.sbl.sulmun2yong.fixture.survey.SurveyFixtureFactory.TARGET_PARTICIPAN
 import com.sbl.sulmun2yong.fixture.survey.SurveyFixtureFactory.THUMBNAIL
 import com.sbl.sulmun2yong.fixture.survey.SurveyFixtureFactory.TITLE
 import com.sbl.sulmun2yong.fixture.survey.SurveyFixtureFactory.createSurvey
+import com.sbl.sulmun2yong.global.util.DateUtil
 import com.sbl.sulmun2yong.survey.domain.response.SectionResponse
 import com.sbl.sulmun2yong.survey.domain.response.SurveyResponse
 import com.sbl.sulmun2yong.survey.domain.routing.RoutingStrategy
@@ -21,6 +22,7 @@ import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyResponseException
+import com.sbl.sulmun2yong.survey.exception.InvalidSurveyStartException
 import com.sbl.sulmun2yong.survey.exception.InvalidUpdateSurveyException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -383,5 +385,46 @@ class SurveyTest {
                 sections = survey3.sections,
             )
         }
+    }
+
+    @Test
+    fun `설문을 시작하면, 설문의 시작일과 상태가 업데이트된다`() {
+        // given
+        val survey = createSurvey(finishedAt = DateUtil.getDateAfterDay(), publishedAt = null, status = SurveyStatus.NOT_STARTED)
+
+        // when
+        val startedSurvey = survey.start()
+
+        // then
+        assertEquals(DateUtil.getCurrentDate(), startedSurvey.publishedAt)
+        assertEquals(SurveyStatus.IN_PROGRESS, startedSurvey.status)
+    }
+
+    @Test
+    fun `설문이 시작 전 상태가 아니면 시작할 수 없다`() {
+        // given
+        val survey1 =
+            createSurvey(
+                finishedAt = DateUtil.getDateAfterDay(),
+                publishedAt = DateUtil.getCurrentDate(),
+                status = SurveyStatus.IN_PROGRESS,
+            )
+        val survey2 =
+            createSurvey(
+                finishedAt = DateUtil.getDateAfterDay(),
+                publishedAt = DateUtil.getCurrentDate(),
+                status = SurveyStatus.IN_MODIFICATION,
+            )
+        val survey3 =
+            createSurvey(
+                finishedAt = DateUtil.getDateAfterDay(),
+                publishedAt = DateUtil.getCurrentDate(),
+                status = SurveyStatus.CLOSED,
+            )
+
+        // when, then
+        assertThrows<InvalidSurveyStartException> { survey1.start() }
+        assertThrows<InvalidSurveyStartException> { survey2.start() }
+        assertThrows<InvalidSurveyStartException> { survey3.start() }
     }
 }

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -109,7 +109,7 @@ class SurveyTest {
             assertEquals(Survey.DEFAULT_FINISH_MESSAGE, this.finishMessage)
             assertEquals(Survey.DEFAULT_TARGET_PARTICIPANT_COUNT, this.targetParticipantCount)
             assertEquals(makerId, this.makerId)
-            assertEquals(emptyList(), this.rewards)
+            assertEquals(listOf(Reward.create()), this.rewards)
             assertEquals(listOf(this.sections.first()), this.sections)
         }
     }
@@ -151,6 +151,12 @@ class SurveyTest {
         assertThrows<InvalidSurveyException> { createSurvey(publishedAt = null, status = SurveyStatus.IN_PROGRESS) }
         assertThrows<InvalidSurveyException> { createSurvey(publishedAt = null, status = SurveyStatus.IN_MODIFICATION) }
         assertThrows<InvalidSurveyException> { createSurvey(publishedAt = null, status = SurveyStatus.CLOSED) }
+    }
+
+    // TODO: 추후에 리워드가 없는 설문도 생성할 수 있도록 수정하기
+    @Test
+    fun `설문에는 최소 한 개의 리워드가 있어야한다`() {
+        assertThrows<InvalidSurveyException> { createSurvey(rewards = emptyList()) }
     }
 
     @Test


### PR DESCRIPTION
## 📢 설명
- 설문 시작 API 구현
- 설문 최초 생성 시 기본 리워드를 하나 추가하도록 수정
- 설문 생성 시 rewards가 비어있으면 예외가 발생하도록 수정
- 추첨 관련 테스트 코드 수정

## ✅ 체크 리스트
- [x] Notion의 설문 제작 Flow에 따라서 진행해서, 설문이 제대로 시작되고, 추첨 보드가 생성되는지 확인
- [x] 설문 생성 API 호출 시 기본 reward가 포함되는지 확인
