### PR TITLE
[SBL-98] 설문 저장, 설문 제작 정보 API 형식 수정

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySaveRequest.kt
@@ -32,7 +32,7 @@ data class SurveySaveRequest(
     )
 
     data class SectionCreateRequest(
-        val id: UUID,
+        val sectionId: UUID,
         val title: String,
         val description: String,
         val questions: List<QuestionCreateRequest>,
@@ -40,7 +40,7 @@ data class SurveySaveRequest(
     ) {
         fun toDomain(sectionIds: SectionIds) =
             Section(
-                id = SectionId.Standard(id),
+                id = SectionId.Standard(sectionId),
                 title = title,
                 description = description,
                 routingStrategy = getRoutingStrategy(),
@@ -76,7 +76,7 @@ data class SurveySaveRequest(
     )
 
     data class QuestionCreateRequest(
-        val id: UUID,
+        val questionId: UUID,
         val type: QuestionType,
         val title: String,
         val description: String,
@@ -88,14 +88,14 @@ data class SurveySaveRequest(
             when (type) {
                 QuestionType.TEXT_RESPONSE ->
                     StandardTextQuestion(
-                        id = id,
+                        id = questionId,
                         title = title,
                         description = description,
                         isRequired = isRequired,
                     )
                 QuestionType.SINGLE_CHOICE ->
                     StandardSingleChoiceQuestion(
-                        id = id,
+                        id = questionId,
                         title = title,
                         description = description,
                         isRequired = isRequired,
@@ -107,7 +107,7 @@ data class SurveySaveRequest(
                     )
                 QuestionType.MULTIPLE_CHOICE ->
                     StandardMultipleChoiceQuestion(
-                        id = id,
+                        id = questionId,
                         title = title,
                         description = description,
                         isRequired = isRequired,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyMakeInfoResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyMakeInfoResponse.kt
@@ -45,7 +45,7 @@ data class SurveyMakeInfoResponse(
     )
 
     data class SectionMakeInfoResponse(
-        val id: UUID,
+        val sectionId: UUID,
         val title: String,
         val description: String,
         val questions: List<QuestionMakeInfoResponse>,
@@ -54,7 +54,7 @@ data class SurveyMakeInfoResponse(
         companion object {
             fun from(section: Section) =
                 SectionMakeInfoResponse(
-                    id = section.id.value,
+                    sectionId = section.id.value,
                     title = section.title,
                     description = section.description,
                     questions = section.questions.map { QuestionMakeInfoResponse.from(it) },
@@ -96,7 +96,7 @@ data class SurveyMakeInfoResponse(
     )
 
     data class QuestionMakeInfoResponse(
-        val id: UUID,
+        val questionId: UUID,
         val type: QuestionType,
         val title: String,
         val description: String,
@@ -107,7 +107,7 @@ data class SurveyMakeInfoResponse(
         companion object {
             fun from(question: Question) =
                 QuestionMakeInfoResponse(
-                    id = question.id,
+                    questionId = question.id,
                     type = question.questionType,
                     title = question.title,
                     description = question.description,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -37,7 +37,7 @@ class SurveyManagementService(
         val rewards = surveySaveRequest.rewards.map { Reward(name = it.name, category = it.category, count = it.count) }
         val newSurvey =
             with(surveySaveRequest) {
-                val sectionIds = SectionIds.from(surveySaveRequest.sections.map { SectionId.Standard(it.id) })
+                val sectionIds = SectionIds.from(surveySaveRequest.sections.map { SectionId.Standard(it.sectionId) })
                 survey.updateContent(
                     title = this.title,
                     description = this.description,


### PR DESCRIPTION
## 📢 설명
- 설문 저장, 설문 제작 정보 API 형식 수정

## ✅ 체크 리스트
- [x] 설문 저장 API의 RequestBody과 노션의 API 형식과 같은지 확인
- [ ] 설문 제작 정보 API의 ResponseBody가 노션의 API 형식과 같은지 확인
