### PR TITLE
[SBL-106] 여러 상황별 리디렉션 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
@@ -22,8 +22,6 @@ import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
-import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.provisioning.InMemoryUserDetailsManager
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
@@ -50,7 +48,7 @@ class SecurityConfig(
     fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 
     @Bean
-    fun cookieAuthorizationRequestRepository(): AuthorizationRequestRepository<OAuth2AuthorizationRequest> =
+    fun cookieAuthorizationRequestRepository(): HttpCookieOAuth2AuthorizationRequestRepository =
         HttpCookieOAuth2AuthorizationRequestRepository()
 
     @Bean
@@ -110,13 +108,11 @@ class SecurityConfig(
                     baseUri = "/oauth2/authorization"
                     authorizationRequestRepository = cookieAuthorizationRequestRepository()
                 }
-                redirectionEndpoint {
-                    baseUri = "/login/oauth2/code/*"
-                }
                 userInfoEndpoint {
                     userService = customOAuth2Service
                 }
-                authenticationSuccessHandler = CustomAuthenticationSuccessHandler(frontendBaseUrl, backendBaseUrl)
+                authenticationSuccessHandler =
+                    CustomAuthenticationSuccessHandler(frontendBaseUrl, backendBaseUrl, cookieAuthorizationRequestRepository())
             }
             logout {
                 logoutUrl = "/user/logout"

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SecurityConfig.kt
@@ -33,7 +33,9 @@ import org.springframework.web.filter.ForwardedHeaderFilter
 @Configuration
 class SecurityConfig(
     @Value("\${frontend.base-url}")
-    private val frontEndBaseUrl: String,
+    private val frontendBaseUrl: String,
+    @Value("\${backend.base-url}")
+    private val backendBaseUrl: String,
     @Value("\${swagger.username}")
     private val username: String?,
     @Value("\${swagger.password}")
@@ -114,12 +116,12 @@ class SecurityConfig(
                 userInfoEndpoint {
                     userService = customOAuth2Service
                 }
-                authenticationSuccessHandler = CustomAuthenticationSuccessHandler(frontEndBaseUrl)
+                authenticationSuccessHandler = CustomAuthenticationSuccessHandler(frontendBaseUrl, backendBaseUrl)
             }
             logout {
                 logoutUrl = "/user/logout"
                 invalidateHttpSession = false
-                logoutSuccessHandler = CustomLogoutSuccessHandler(frontEndBaseUrl, sessionRegistry())
+                logoutSuccessHandler = CustomLogoutSuccessHandler(frontendBaseUrl, sessionRegistry())
             }
             authorizeHttpRequests {
                 authorize("/api/v1/admin/**", hasRole("ADMIN"))

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/WebMvcConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/WebMvcConfig.kt
@@ -11,14 +11,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 @Configuration
 class WebMvcConfig(
     @Value("\${frontend.base-url}")
-    private val baseUrl: String,
+    private val frontendBaseUrl: String,
     private val loginUserArgumentResolver: LoginUserArgumentResolver,
     private val isAdminArgumentResolver: IsAdminArgumentResolver,
 ) : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry
             .addMapping("/**")
-            .allowedOrigins(baseUrl) // 프론트엔드 도메인
+            .allowedOrigins(frontendBaseUrl) // 프론트엔드 도메인
             .allowedMethods("GET", "POST", "PUT", "DELETE")
             .allowCredentials(true)
             .allowedHeaders("*")

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
@@ -33,8 +33,7 @@ class CustomOAuth2Service(
         val providerId = oAuth2UserInfo.getProviderId()
         val phoneNumber: String? = oAuth2UserInfo.getPhoneNumber()
 
-        // TODO: 전화번호가 등록되어 있는 유저가 소셜로그인에서 전화번호를 제공하지 않는 Google이나 Kakao로 로그인 시
-        //  전화번호가 사라지고 ROLE이 변경되는 문제 수정하기
+        // TODO: 전화번호가 등록되어 있는 유저가 소셜로그인에서 전화번호를 제공하지 않는 Google이나 Kakao로 로그인 시 전화번호가 사라지고 ROLE이 변경되는 문제 수정하기
         val user: User? = userAdapter.findByProviderAndProviderId(provider, providerId)
         val upsertedUser =
             user?.withUpdatePhoneNumber(phoneNumber)

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2Service.kt
@@ -31,10 +31,12 @@ class CustomOAuth2Service(
         val oAuth2UserInfo = getOAuth2UserInfo(oAuth2UserRequest, oAuth2User)
         val provider = oAuth2UserInfo.getProvider()
         val providerId = oAuth2UserInfo.getProviderId()
-        val phoneNumber: String? = oAuth2UserInfo.getPhoneNumber()
 
-        // TODO: 전화번호가 등록되어 있는 유저가 소셜로그인에서 전화번호를 제공하지 않는 Google이나 Kakao로 로그인 시 전화번호가 사라지고 ROLE이 변경되는 문제 수정하기
         val user: User? = userAdapter.findByProviderAndProviderId(provider, providerId)
+        val currentPhoneNumber = user?.phoneNumber?.value
+
+        val phoneNumber: String? = currentPhoneNumber ?: oAuth2UserInfo.getPhoneNumber()
+
         val upsertedUser =
             user?.withUpdatePhoneNumber(phoneNumber)
                 ?: User.create(

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/CustomOAuth2User.kt
@@ -27,5 +27,6 @@ data class CustomOAuth2User(
         DefaultUserProfile(
             id = id,
             nickname = nickname,
+            role = role,
         )
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -10,11 +10,12 @@ import org.springframework.stereotype.Component
 
 @Component
 class HttpCookieOAuth2AuthorizationRequestRepository : AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
-    override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? =
-        CookieUtils
-            .getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
-            .map { cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest::class.java) }
-            .orElse(null)
+    override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? {
+        val cookie = CookieUtils.findCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        return cookie?.let {
+            CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest::class.java)
+        }
+    }
 
     override fun removeAuthorizationRequest(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -1,0 +1,62 @@
+package com.sbl.sulmun2yong.global.config.oauth2
+
+import com.nimbusds.oauth2.sdk.util.StringUtils
+import com.sbl.sulmun2yong.global.util.CookieUtils
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.stereotype.Component
+
+@Component
+class HttpCookieOAuth2AuthorizationRequestRepository : AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? =
+        CookieUtils
+            .getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            .map { cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest::class.java) }
+            .orElse(null)
+
+    override fun removeAuthorizationRequest(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): OAuth2AuthorizationRequest? = this.loadAuthorizationRequest(request)
+
+    override fun saveAuthorizationRequest(
+        authorizationRequest: OAuth2AuthorizationRequest?,
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME)
+            return
+        }
+
+        CookieUtils.addCookie(
+            response,
+            OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+            CookieUtils.serialize(authorizationRequest),
+            COOKIE_EXPIRE_SECONDS,
+        )
+        val redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME)
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS)
+        }
+    }
+
+    fun removeAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? = this.loadAuthorizationRequest(request)
+
+    fun removeAuthorizationRequestCookies(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME)
+    }
+
+    companion object {
+        const val OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME: String = "oauth2_auth_request"
+        const val REDIRECT_URI_PARAM_COOKIE_NAME: String = "redirect_uri"
+        private const val COOKIE_EXPIRE_SECONDS = 180
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -6,9 +6,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
-import org.springframework.stereotype.Component
 
-@Component
 class HttpCookieOAuth2AuthorizationRequestRepository : AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
     override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? {
         val cookie = CookieUtils.findCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
@@ -44,8 +42,6 @@ class HttpCookieOAuth2AuthorizationRequestRepository : AuthorizationRequestRepos
             CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, COOKIE_EXPIRE_SECONDS)
         }
     }
-
-    fun removeAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? = this.loadAuthorizationRequest(request)
 
     fun removeAuthorizationRequestCookies(
         request: HttpServletRequest,

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
@@ -3,6 +3,7 @@ package com.sbl.sulmun2yong.global.config.oauth2.handler
 import com.sbl.sulmun2yong.global.config.oauth2.CustomOAuth2User
 import com.sbl.sulmun2yong.global.config.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.Companion.REDIRECT_URI_PARAM_COOKIE_NAME
 import com.sbl.sulmun2yong.global.util.CookieUtils
+import com.sbl.sulmun2yong.user.domain.UserRole
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -10,19 +11,14 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 
 class CustomAuthenticationSuccessHandler(
-    private val frontEndBaseUrl: String,
+    private val frontendBaseUrl: String,
+    private val backendBaseUrl: String,
 ) : AuthenticationSuccessHandler {
     override fun onAuthenticationSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
         authentication: Authentication,
     ) {
-        // 상태 코드 설정
-        val redirectUri =
-            CookieUtils
-                .getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                .map(Cookie::getValue)
-
         val principal = authentication.principal
         val defaultUserProfile =
             if (principal is CustomOAuth2User) {
@@ -31,12 +27,20 @@ class CustomAuthenticationSuccessHandler(
                 throw IllegalArgumentException("CustomOAuth2User 타입이 아닙니다.")
             }
 
+        val redirectUriCookieValue = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME).value
+        val redirectUri =
+            if (redirectUriCookieValue == backendBaseUrl && defaultUserProfile.role != UserRole.ROLE_ADMIN) {
+                frontendBaseUrl
+            } else {
+                redirectUriCookieValue
+            }
+
         // 기본 프로필 쿠키 생성
         val cookie = Cookie("user-profile", defaultUserProfile.toBase64Json())
         cookie.path = "/"
         response.addCookie(cookie)
 
         // 리디렉트
-        response.sendRedirect("$frontEndBaseUrl/")
+        response.sendRedirect(redirectUri)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/oauth2/handler/CustomAuthenticationSuccessHandler.kt
@@ -1,10 +1,11 @@
 package com.sbl.sulmun2yong.global.config.oauth2.handler
 
 import com.sbl.sulmun2yong.global.config.oauth2.CustomOAuth2User
+import com.sbl.sulmun2yong.global.config.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.Companion.REDIRECT_URI_PARAM_COOKIE_NAME
+import com.sbl.sulmun2yong.global.util.CookieUtils
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.http.HttpStatus
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 
@@ -17,7 +18,10 @@ class CustomAuthenticationSuccessHandler(
         authentication: Authentication,
     ) {
         // 상태 코드 설정
-        response.status = HttpStatus.OK.value()
+        val redirectUri =
+            CookieUtils
+                .getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
 
         val principal = authentication.principal
         val defaultUserProfile =

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/CookieUtils.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/CookieUtils.kt
@@ -9,7 +9,7 @@ import java.util.Base64
 object CookieUtils {
     fun getCookie(
         request: HttpServletRequest,
-        name: String?,
+        name: String,
     ): Cookie {
         val cookies: Array<Cookie> = request.cookies
 
@@ -19,7 +19,7 @@ object CookieUtils {
 
     fun findCookie(
         request: HttpServletRequest,
-        name: String?,
+        name: String,
     ): Cookie? {
         val cookies: Array<Cookie> = request.cookies
         return cookies.firstOrNull { it.name == name }
@@ -27,8 +27,8 @@ object CookieUtils {
 
     fun addCookie(
         response: HttpServletResponse,
-        name: String?,
-        value: String?,
+        name: String,
+        value: String,
         maxAge: Int,
     ) {
         val cookie = Cookie(name, value)
@@ -41,7 +41,7 @@ object CookieUtils {
     fun deleteCookie(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        name: String?,
+        name: String,
     ) {
         val cookies: Array<Cookie>? = request.cookies
         if (cookies.isNullOrEmpty()) {
@@ -58,7 +58,7 @@ object CookieUtils {
         }
     }
 
-    fun serialize(cookieObject: Any?): String =
+    fun serialize(cookieObject: Any): String =
         Base64
             .getUrlEncoder()
             .encodeToString(SerializationUtils.serialize(cookieObject))

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/CookieUtils.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/CookieUtils.kt
@@ -1,0 +1,73 @@
+package com.sbl.sulmun2yong.global.util
+
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.util.SerializationUtils
+import java.util.Base64
+import java.util.Optional
+
+object CookieUtils {
+    fun getCookie(
+        request: HttpServletRequest,
+        name: String?,
+    ): Optional<Cookie> {
+        val cookies: Array<Cookie>? = request.cookies
+
+        if (cookies != null && cookies.size > 0) {
+            for (cookie in cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of<Cookie>(cookie)
+                }
+            }
+        }
+
+        return Optional.empty<Cookie>()
+    }
+
+    fun addCookie(
+        response: HttpServletResponse,
+        name: String?,
+        value: String?,
+        maxAge: Int,
+    ) {
+        val cookie: Cookie = Cookie(name, value)
+        cookie.setPath("/")
+        cookie.setHttpOnly(true)
+        cookie.setMaxAge(maxAge)
+        response.addCookie(cookie)
+    }
+
+    fun deleteCookie(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        name: String?,
+    ) {
+        val cookies: Array<Cookie>? = request.cookies
+        if (cookies != null && cookies.size > 0) {
+            for (cookie in cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("")
+                    cookie.setPath("/")
+                    cookie.setMaxAge(0)
+                    response.addCookie(cookie)
+                }
+            }
+        }
+    }
+
+    fun serialize(`object`: Any?): String =
+        Base64
+            .getUrlEncoder()
+            .encodeToString(SerializationUtils.serialize(`object`))
+
+    fun <T> deserialize(
+        cookie: Cookie,
+        cls: Class<T>,
+    ): T =
+        cls.cast(
+            SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue()),
+            ),
+        )
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
@@ -30,6 +30,7 @@ class LoginController(
 
         val oauth2RedirectUrl = "/oauth2/authorization/$provider?redirect_uri=$userRedirectUrl"
         httpHeaders.location = URI.create(oauth2RedirectUrl)
+
         return ResponseEntity(httpHeaders, HttpStatus.FOUND)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
@@ -2,34 +2,45 @@ package com.sbl.sulmun2yong.user.controller
 
 import com.sbl.sulmun2yong.user.controller.doc.LoginApiDoc
 import jakarta.servlet.http.HttpServletRequest
-import jakarta.ws.rs.QueryParam
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
 @RestController("/api/v1/login")
 class LoginController(
-    @Value("\${backend.base-url}")
-    private val backendBaseUrl: String,
+    @Value("\${frontend.base-url}")
+    private val frontendBaseUrl: String,
 ) : LoginApiDoc {
     @GetMapping("/oauth/{provider}")
     @ResponseBody
     override fun login(
         @PathVariable provider: String,
-        @QueryParam("redirect_uri") redirectUrl: String?,
+        @RequestParam("redirect_path") redirectPathAfterLogin: String?,
         request: HttpServletRequest,
     ): ResponseEntity<Any> {
-        val userRedirectUrl = redirectUrl ?: backendBaseUrl
         val httpHeaders = HttpHeaders()
 
-        val oauth2RedirectUrl = "/oauth2/authorization/$provider?redirect_uri=$userRedirectUrl"
-        httpHeaders.location = URI.create(oauth2RedirectUrl)
+        val redirectUriAfterLogin =
+            redirectPathAfterLogin?. let {
+                URI.create(frontendBaseUrl + it)
+            }
+
+        val redirectUriForOAuth2 =
+            UriComponentsBuilder
+                .fromPath("/oauth2/authorization/{provider}")
+                .queryParam("redirect_uri", redirectUriAfterLogin)
+                .buildAndExpand(provider)
+                .toUriString()
+
+        httpHeaders.location = URI.create(redirectUriForOAuth2)
 
         return ResponseEntity(httpHeaders, HttpStatus.FOUND)
     }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
@@ -22,10 +22,10 @@ class LoginController(
     @ResponseBody
     override fun login(
         @PathVariable provider: String,
-        @QueryParam("redirect_uri") redirectUri: String?,
+        @QueryParam("redirect_uri") redirectUrl: String?,
         request: HttpServletRequest,
     ): ResponseEntity<Any> {
-        val userRedirectUrl = redirectUri ?: backendBaseUrl
+        val userRedirectUrl = redirectUrl ?: backendBaseUrl
         val httpHeaders = HttpHeaders()
 
         val oauth2RedirectUrl = "/oauth2/authorization/$provider?redirect_uri=$userRedirectUrl"

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
@@ -1,0 +1,24 @@
+package com.sbl.sulmun2yong.user.controller
+
+import com.sbl.sulmun2yong.user.controller.doc.LoginApiDoc
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@RestController("/api/v1/login")
+class LoginController : LoginApiDoc {
+    @GetMapping("/oauth/{provider}")
+    @ResponseBody
+    override fun login(
+        @PathVariable provider: String,
+    ): ResponseEntity<Any> {
+        val httpHeaders = HttpHeaders()
+        httpHeaders.location = URI.create("http://localhost:8080/oauth2/authorization/$provider")
+        return ResponseEntity(httpHeaders, HttpStatus.FOUND)
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/LoginController.kt
@@ -1,6 +1,9 @@
 package com.sbl.sulmun2yong.user.controller
 
 import com.sbl.sulmun2yong.user.controller.doc.LoginApiDoc
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.ws.rs.QueryParam
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -11,14 +14,22 @@ import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
 @RestController("/api/v1/login")
-class LoginController : LoginApiDoc {
+class LoginController(
+    @Value("\${backend.base-url}")
+    private val backendBaseUrl: String,
+) : LoginApiDoc {
     @GetMapping("/oauth/{provider}")
     @ResponseBody
     override fun login(
         @PathVariable provider: String,
+        @QueryParam("redirect_uri") redirectUri: String?,
+        request: HttpServletRequest,
     ): ResponseEntity<Any> {
+        val userRedirectUrl = redirectUri ?: backendBaseUrl
         val httpHeaders = HttpHeaders()
-        httpHeaders.location = URI.create("http://localhost:8080/oauth2/authorization/$provider")
+
+        val oauth2RedirectUrl = "/oauth2/authorization/$provider?redirect_uri=$userRedirectUrl"
+        httpHeaders.location = URI.create(oauth2RedirectUrl)
         return ResponseEntity(httpHeaders, HttpStatus.FOUND)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/LoginApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/LoginApiDoc.kt
@@ -2,6 +2,8 @@ package com.sbl.sulmun2yong.user.controller.doc
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.ws.rs.QueryParam
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -16,5 +18,7 @@ interface LoginApiDoc {
     @ResponseBody
     fun login(
         @PathVariable provider: String,
+        @QueryParam("redirectUrl") redirectUrl: String?,
+        request: HttpServletRequest,
     ): ResponseEntity<Any>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/LoginApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/LoginApiDoc.kt
@@ -18,7 +18,7 @@ interface LoginApiDoc {
     @ResponseBody
     fun login(
         @PathVariable provider: String,
-        @QueryParam("redirectUrl") redirectUrl: String?,
+        @QueryParam("redirect_path") redirectPathAfterLogin: String?,
         request: HttpServletRequest,
     ): ResponseEntity<Any>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/LoginApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/LoginApiDoc.kt
@@ -1,0 +1,20 @@
+package com.sbl.sulmun2yong.user.controller.doc
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+
+@Tag(name = "Login", description = "로그인 API")
+@RequestMapping("/api/v1/login")
+interface LoginApiDoc {
+    @Operation(summary = "oauth 로그인")
+    @GetMapping("/login/{provider}")
+    @ResponseBody
+    fun login(
+        @PathVariable provider: String,
+    ): ResponseEntity<Any>
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/domain/User.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/domain/User.kt
@@ -14,9 +14,11 @@ data class User(
     var phoneNumber: PhoneNumber?,
     val role: UserRole,
 ) {
-    // TODO: UserRole이 AUTHENTICATED_USER일 경우 phoneNumber는 null이 아닌지 검사
     init {
         if (nickname.length !in 2..10) {
+            throw InvalidUserException()
+        }
+        if (this.role == UserRole.ROLE_AUTHENTICATED_USER && phoneNumber == null) {
             throw InvalidUserException()
         }
     }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/dto/DefaultUserProfile.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/dto/DefaultUserProfile.kt
@@ -1,12 +1,14 @@
 package com.sbl.sulmun2yong.user.dto
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.sbl.sulmun2yong.user.domain.UserRole
 import java.util.Base64
 import java.util.UUID
 
 data class DefaultUserProfile(
     val id: UUID,
     val nickname: String,
+    val role: UserRole,
 ) {
     fun toBase64Json(): String {
         val objectMapper = ObjectMapper()


### PR DESCRIPTION
## 📢 설명
- TODO 구현
전화번호가 있는 사용자가 전화번호가 제공되지 않는 OATUH2로그인을 하면 전화번호가 없어지는 문제
AUTHENTICATE_USER라면 전화번호가 null이 아닌지 검사

- 프론트엔드에서 ```redirection_path``` 쿼리 파라미터를 주어 로그인 성공 후 원하는 path로 리디렉션 시킬 수 있음
- redirection_path없이 oauth2 로그인하면
```ROLE_ADMIN```은 ```backendBaseUrl```로 리디렉션됨
그 외에는 기본적으로 ```frontendBaseUrl```로 리디렉션됨
-  ```HttpCookieOAuth2AuthorizationRequestRepository``` 도입
현재는 oauth2서버와 통신간에 사용
이후 jwt도입시에도 활용 가능
- redirection_path 쿼리 파라미터 주고 로그인하는 예시 
```
location.href = "http://localhost:8080/api/v1/login/oauth/kakao?redirect_path=" + "/s/1b071051-c753-4e0a-91ae-0035ddc8d3d3"
```
- redirection_path 쿼리 파라미터 안주고 로그인하는 예시 
```
location.href = "http://localhost:8080/api/v1/login/oauth/kakao"
```

## ✅ 체크 리스트
- [x] 전화번호가 있는 사용자가 전화번호가 제공되지 않는 OATUH2로그인을 해도 전화번호가 남아있는지 확인
- [x] AUTHENTICATE_USER가 전화번호가 null이라면 예외가 발생하는지 확인
- [x] redirection_path를 주지않고 관리자 권한을 가진 유저로 로그인하면 backendBaseURL로 이동하는지 확인
- [x] redirection_path를 주지않고 관리자가 아닌 권한을 가진 유저로 로그인하면 frontendBaseURL로 이동하는지 확인
- [x] redirection_path를 주고 관리자 권한을 가진 유저로 로그인하면 그 redirection_path로 로그인 후 이동하는지 확인
- [x] redirection_path를 주고 관리자가 아닌 유저로 로그인하면 그 redirection_path로 로그인 후 이동하는지 확인
- [ ] 그 외의 코드 리뷰
