### PR TITLE
[SBL-118] createdAt 컬럼이 매번 업데이트되던 오류 수정

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/adapter/DrawingBoardAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/adapter/DrawingBoardAdapter.kt
@@ -18,6 +18,10 @@ class DrawingBoardAdapter(
             .toDomain()
 
     fun save(drawingBoard: DrawingBoard) {
-        drawingBoardRepository.save(DrawingBoardDocument.of(drawingBoard))
+        val previousDrawingBoardDocument = drawingBoardRepository.findById(drawingBoard.id)
+        val drawingBoardDocument = DrawingBoardDocument.of(drawingBoard)
+        // 기존 추첨 보드를 업데이트하는 경우, createdAt을 유지
+        if (previousDrawingBoardDocument.isPresent) drawingBoardDocument.createdAt = previousDrawingBoardDocument.get().createdAt
+        drawingBoardRepository.save(drawingBoardDocument)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/adapter/DrawingHistoryAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/adapter/DrawingHistoryAdapter.kt
@@ -13,8 +13,8 @@ import java.util.UUID
 class DrawingHistoryAdapter(
     private val drawingHistoryRepository: DrawingHistoryRepository,
 ) {
-    fun save(drawingHistory: DrawingHistory) {
-        drawingHistoryRepository.save(DrawingHistoryDocument.of(drawingHistory))
+    fun insert(drawingHistory: DrawingHistory) {
+        drawingHistoryRepository.insert(DrawingHistoryDocument.of(drawingHistory))
     }
 
     fun findBySurveyIdAndParticipantIdOrPhoneNumber(

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/entity/DrawingHistoryDocument.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/entity/DrawingHistoryDocument.kt
@@ -3,6 +3,7 @@ package com.sbl.sulmun2yong.drawing.entity
 import com.sbl.sulmun2yong.drawing.domain.DrawingHistory
 import com.sbl.sulmun2yong.drawing.domain.ticket.Ticket
 import com.sbl.sulmun2yong.global.data.PhoneNumber
+import com.sbl.sulmun2yong.global.entity.BaseTimeDocument
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
 import java.util.UUID
@@ -16,7 +17,7 @@ data class DrawingHistoryDocument(
     val surveyId: UUID,
     val selectedTicketIndex: Int,
     val ticket: Ticket,
-) {
+) : BaseTimeDocument() {
     companion object {
         fun of(drawingHistory: DrawingHistory) =
             DrawingHistoryDocument(

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardService.kt
@@ -72,7 +72,7 @@ class DrawingBoardService(
         val changedDrawingBoard = drawingResult.changedDrawingBoard
         drawingBoardAdapter.save(drawingResult.changedDrawingBoard)
         // 추첨 기록 저장
-        drawingHistoryAdapter.save(
+        drawingHistoryAdapter.insert(
             DrawingHistory.create(
                 participantId = participantId,
                 phoneNumber = phoneNumberData,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/ParticipantAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/ParticipantAdapter.kt
@@ -11,8 +11,8 @@ import java.util.UUID
 class ParticipantAdapter(
     val participantRepository: ParticipantRepository,
 ) {
-    fun saveParticipant(participant: Participant) {
-        participantRepository.save(ParticipantDocument.of(participant))
+    fun insert(participant: Participant) {
+        participantRepository.insert(ParticipantDocument.of(participant))
     }
 
     fun getParticipant(id: UUID): Participant =

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/ResponseAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/ResponseAdapter.kt
@@ -10,11 +10,11 @@ import java.util.UUID
 class ResponseAdapter(
     private val responseRepository: ResponseRepository,
 ) {
-    fun saveSurveyResponse(
+    fun insertSurveyResponse(
         surveyResponse: SurveyResponse,
         participantId: UUID,
     ) {
-        responseRepository.saveAll(surveyResponse.toDocuments(participantId))
+        responseRepository.insert(surveyResponse.toDocuments(participantId))
     }
 
     private fun SurveyResponse.toDocuments(participantId: UUID): List<ResponseDocument> =

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -45,6 +45,10 @@ class SurveyAdapter(
     }
 
     fun save(survey: Survey) {
-        surveyRepository.save(SurveyDocument.from(survey))
+        val previousSurveyDocument = surveyRepository.findById(survey.id)
+        val surveyDocument = SurveyDocument.from(survey)
+        // 기존 설문을 업데이트하는 경우, createdAt을 유지
+        if (previousSurveyDocument.isPresent) surveyDocument.createdAt = previousSurveyDocument.get().createdAt
+        surveyRepository.save(surveyDocument)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResponseService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResponseService.kt
@@ -41,8 +41,8 @@ class SurveyResponseService(
         survey.validateResponse(surveyResponse)
         // TODO: 참가자 객체의 UserId에 실제 유저 값 넣기
         val participant = Participant.create(visitorId, surveyId, null)
-        participantAdapter.saveParticipant(participant)
-        responseAdapter.saveSurveyResponse(surveyResponse, participant.id)
+        participantAdapter.insert(participant)
+        responseAdapter.insertSurveyResponse(surveyResponse, participant.id)
         return SurveyParticipantResponse(participant.id, survey.isImmediateDraw())
     }
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/adapter/UserAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/adapter/UserAdapter.kt
@@ -13,7 +13,11 @@ class UserAdapter(
     private val userRepository: UserRepository,
 ) {
     fun save(user: User) {
-        userRepository.save(UserDocument.of(user))
+        val previousUserDocument = userRepository.findById(user.id)
+        val userDocument = UserDocument.of(user)
+        // 기존 유저를 업데이트하는 경우, createdAt을 유지
+        if (previousUserDocument.isPresent) userDocument.createdAt = previousUserDocument.get().createdAt
+        userRepository.save(userDocument)
     }
 
     fun getById(id: UUID): User =


### PR DESCRIPTION
## 📢 설명

- createdAt 컬럼이 수정 시 마다 함께 업데이트되는 오류 수정
- 기존 값 업데이트 시 createdAt 컬럼을 제외하고 업데이트 하도록 변경
- 기존에 값을 업데이트하지 않고 insert만 하던 save메서드를 insert로 변경

## ✅ 체크 리스트

- [x]  admin 계정으로 로그인한 뒤 User의 createdAt과 updatedAt이 올바른지 확인
- [x]  설문 생성 API 호출한 뒤 아래 requestBody로 설문 저장 API 호출한 뒤 DB에서 Survey의 createdAt과 updatedAt이 올바른지 확인
    
    ```json
    {
      "title": "제목 없는 설문",
      "description": "",
      "thumbnail": null,
      "publishedAt": null,
      "finishedAt": "2024-11-03T08:49:00.000+00:00",
      "status": "NOT_STARTED",
      "finishMessage": "설문에 참여해주셔서 감사합니다.",
      "targetParticipantCount": 100,
      "rewards": [
        {
          "name": "커피",
          "category": "커피",
          "count": 10
        }
      ],
      "isVisible": true,
      "sections": [
        {
          "sectionId": "93f4d127-ca3f-43c2-83d2-bc610bc69881",
          "title": "제목 없는 섹션",
          "description": "",
          "questions": [
            {
              "questionId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
              "type": "TEXT_RESPONSE",
              "title": "string",
              "description": "string",
              "isRequired": true,
              "isAllowOther": true,
              "choices": null
            }
          ],
          "routeDetails": {
            "type": "NUMERICAL_ORDER",
            "nextSectionId": null,
            "keyQuestionId": null,
            "sectionRouteConfigs": null
          }
        }
      ]
    }
    ```
    
- [x]  설문 시작 API 호출한 뒤, 아래 requestBody로 설문 응답 API 호출한 뒤 DB에서 Participant와 Response의 createdAt과 updatedAt이 올바른지 확인
    
    ```json
    {
      "sectionResponses": [
        {
          "sectionId": "93f4d127-ca3f-43c2-83d2-bc610bc69881",
          "questionResponses": [
            {
              "questionId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
              "responses": [
                {
                  "content": "string",
                  "isOther": false
                }
              ]
            }
          ]
        }
      ],
      "visitorId": "string"
    }
    ```
    
- [ ]  설문 응답 API의 participantId를 활용해서 아래의 requestBody로 추첨 API 호출한 뒤 DB에서 DrawingBoard와 DrawingHistory의 createdAt과 updatedAt이 올바른지 확인
    
    ```json
    {
      "participantId": "설문 응답 API의 ResponseBody에 있는 participantId 가져오기",
      "selectedNumber": 10,
      "phoneNumber": "010-5378-8920"
    }
    ```