### PR TITLE
[SBL-136] 설문 수정 관련 기능 추가

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -32,6 +32,7 @@ enum class ErrorCode(
     INVALID_RESULT_DETAILS(HttpStatus.BAD_REQUEST, "SV0020", "유효하지 않은 설문 결과입니다."),
     INVALID_QUESTION_FILTER(HttpStatus.BAD_REQUEST, "SV0021", "유효하지 않은 질문 필터입니다."),
     INVALID_FINISHED_AT(HttpStatus.BAD_REQUEST, "SV0022", "유효하지 않은 마감일입니다."),
+    INVALID_SURVEY_EDIT(HttpStatus.BAD_REQUEST, "SV0023", "설문 수정 상태 변경에 실패했습니다."),
 
     // Drawing (DR)
     INVALID_DRAWING_BOARD(HttpStatus.BAD_REQUEST, "DR0001", "유효하지 않은 추첨 보드입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -33,6 +33,7 @@ enum class ErrorCode(
     INVALID_QUESTION_FILTER(HttpStatus.BAD_REQUEST, "SV0021", "유효하지 않은 질문 필터입니다."),
     INVALID_FINISHED_AT(HttpStatus.BAD_REQUEST, "SV0022", "유효하지 않은 마감일입니다."),
     INVALID_SURVEY_EDIT(HttpStatus.BAD_REQUEST, "SV0023", "설문 수정 상태 변경에 실패했습니다."),
+    INVALID_PUBLISHED_AT(HttpStatus.BAD_REQUEST, "SV0024", "설문 마감일이 설문 공개일 보다 빠릅니다."),
 
     // Drawing (DR)
     INVALID_DRAWING_BOARD(HttpStatus.BAD_REQUEST, "DR0001", "유효하지 않은 추첨 보드입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -1,6 +1,5 @@
 package com.sbl.sulmun2yong.survey.controller
 
-import com.sbl.sulmun2yong.drawing.adapter.DrawingBoardAdapter
 import com.sbl.sulmun2yong.global.annotation.LoginUser
 import com.sbl.sulmun2yong.survey.controller.doc.SurveyManagementApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
@@ -20,7 +19,6 @@ import java.util.UUID
 @RequestMapping("/api/v1/surveys/workbench")
 class SurveyManagementController(
     private val surveyManagementService: SurveyManagementService,
-    private val drawingBoardAdapter: DrawingBoardAdapter,
 ) : SurveyManagementApiDoc {
     @PostMapping("/create")
     override fun createSurvey(
@@ -51,4 +49,10 @@ class SurveyManagementController(
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ) = ResponseEntity.ok(surveyManagementService.startSurvey(surveyId = surveyId, makerId = id))
+
+    @PatchMapping("/edit/{surveyId}")
+    override fun editSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ) = ResponseEntity.ok(surveyManagementService.editSurvey(surveyId = surveyId, makerId = id))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -44,4 +44,11 @@ interface SurveyManagementApiDoc {
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "설문 수정 API")
+    @PatchMapping("/edit/{surveyId}")
+    fun editSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/InvalidSurveyEditException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/InvalidSurveyEditException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.survey.domain
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidSurveyEditException : BusinessException(ErrorCode.INVALID_SURVEY_EDIT)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -107,10 +107,14 @@ data class Survey(
 
     fun finish() = copy(status = SurveyStatus.CLOSED)
 
-    fun start(): Survey {
-        require(status == SurveyStatus.NOT_STARTED) { throw InvalidSurveyStartException() }
-        return copy(status = SurveyStatus.IN_PROGRESS, publishedAt = DateUtil.getCurrentDate())
-    }
+    /** 설문을 IN_PROGRESS 상태로 변경하는 메서드. 설문이 시작 전이거나 수정 중인 경우만 가능하다. */
+    fun start() =
+        when (status) {
+            SurveyStatus.NOT_STARTED -> copy(status = SurveyStatus.IN_PROGRESS, publishedAt = DateUtil.getCurrentDate())
+            SurveyStatus.IN_MODIFICATION -> copy(status = SurveyStatus.IN_PROGRESS)
+            SurveyStatus.IN_PROGRESS -> throw InvalidSurveyStartException()
+            SurveyStatus.CLOSED -> throw InvalidSurveyStartException()
+        }
 
     fun edit(): Survey {
         require(status == SurveyStatus.IN_PROGRESS) { throw InvalidSurveyEditException() }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -112,6 +112,11 @@ data class Survey(
         return copy(status = SurveyStatus.IN_PROGRESS, publishedAt = DateUtil.getCurrentDate())
     }
 
+    fun edit(): Survey {
+        require(status == SurveyStatus.IN_PROGRESS) { throw InvalidSurveyEditException() }
+        return copy(status = SurveyStatus.IN_MODIFICATION)
+    }
+
     fun isImmediateDraw() = rewardSetting.isImmediateDraw
 
     private fun isSectionsUnique() = sections.size == sections.distinctBy { it.id }.size

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -9,6 +9,7 @@ import com.sbl.sulmun2yong.survey.domain.reward.SelfManagementSetting
 import com.sbl.sulmun2yong.survey.domain.section.Section
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
+import com.sbl.sulmun2yong.survey.exception.InvalidPublishedAtException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyResponseException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyStartException
@@ -34,7 +35,7 @@ data class Survey(
         require(sections.isNotEmpty()) { throw InvalidSurveyException() }
         require(isSectionsUnique()) { throw InvalidSurveyException() }
         require(isSurveyStatusValid()) { throw InvalidSurveyException() }
-        require(isFinishedAtAfterPublishedAt()) { throw InvalidSurveyException() }
+        require(isFinishedAtAfterPublishedAt()) { throw InvalidPublishedAtException() }
         require(isSectionIdsValid()) { throw InvalidSurveyException() }
     }
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidPublishedAtException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/InvalidPublishedAtException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.survey.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidPublishedAtException : BusinessException(ErrorCode.INVALID_PUBLISHED_AT)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -88,4 +88,14 @@ class SurveyManagementService(
             drawingBoardAdapter.save(drawingBoard)
         }
     }
+
+    fun editSurvey(
+        surveyId: UUID,
+        makerId: UUID,
+    ) {
+        val survey = surveyAdapter.getSurvey(surveyId)
+        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
+        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
+        surveyAdapter.save(survey.edit())
+    }
 }

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -251,10 +251,14 @@ class SurveyTest {
     @Test
     fun `진행 중인 설문은 수정 중인 상태로 변경할 수 있다`() {
         // given
-        val inProgressSurvey = createSurvey(status = SurveyStatus.IN_PROGRESS, targetParticipantCount = null)
-        val notStartedSurvey = createSurvey(status = SurveyStatus.NOT_STARTED, targetParticipantCount = null)
-        val inModificationSurvey = createSurvey(status = SurveyStatus.IN_MODIFICATION, targetParticipantCount = null)
-        val closedSurvey = createSurvey(status = SurveyStatus.CLOSED, targetParticipantCount = null)
+        val inProgressSurvey =
+            createSurvey(type = RewardSettingType.SELF_MANAGEMENT, status = SurveyStatus.IN_PROGRESS, targetParticipantCount = null)
+        val notStartedSurvey =
+            createSurvey(type = RewardSettingType.SELF_MANAGEMENT, status = SurveyStatus.NOT_STARTED, targetParticipantCount = null)
+        val inModificationSurvey =
+            createSurvey(type = RewardSettingType.SELF_MANAGEMENT, status = SurveyStatus.IN_MODIFICATION, targetParticipantCount = null)
+        val closedSurvey =
+            createSurvey(type = RewardSettingType.SELF_MANAGEMENT, status = SurveyStatus.CLOSED, targetParticipantCount = null)
 
         // when, then
         assertEquals(SurveyStatus.IN_MODIFICATION, inProgressSurvey.edit().status)
@@ -389,6 +393,7 @@ class SurveyTest {
         // given
         val notStartedSurvey =
             createSurvey(
+                type = RewardSettingType.SELF_MANAGEMENT,
                 finishedAt = DateUtil.getDateAfterDay(date = DateUtil.getCurrentDate(noMin = true)),
                 publishedAt = null,
                 targetParticipantCount = null,
@@ -396,6 +401,7 @@ class SurveyTest {
             )
         val inModificationSurvey =
             createSurvey(
+                type = RewardSettingType.SELF_MANAGEMENT,
                 finishedAt = DateUtil.getDateAfterDay(date = DateUtil.getCurrentDate(noMin = true)),
                 targetParticipantCount = null,
                 status = SurveyStatus.IN_MODIFICATION,

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -22,6 +22,7 @@ import com.sbl.sulmun2yong.survey.domain.routing.RoutingStrategy
 import com.sbl.sulmun2yong.survey.domain.section.Section
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
+import com.sbl.sulmun2yong.survey.exception.InvalidPublishedAtException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyResponseException
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyStartException
@@ -139,9 +140,9 @@ class SurveyTest {
             )
         }
         // 리워드 설정이 즉시 추첨인 설문은 시작일이 마감일 이후면 예외가 발생한다.
-        assertThrows<InvalidSurveyException> { createSurvey(publishedAt = publishedAtAfterFinishedAt) }
+        assertThrows<InvalidPublishedAtException> { createSurvey(publishedAt = publishedAtAfterFinishedAt) }
         // 리워드 설정이 직접 관리인 설문은 시작일이 마감일 이후면 예외가 발생한다.
-        assertThrows<InvalidSurveyException> {
+        assertThrows<InvalidPublishedAtException> {
             createSurvey(type = RewardSettingType.SELF_MANAGEMENT, publishedAt = publishedAtAfterFinishedAt, targetParticipantCount = null)
         }
         // 리워드 미 지급 설문은 마감일이 존재하지 않으므로 예외가 발생하지 않는다.

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -249,6 +249,21 @@ class SurveyTest {
     }
 
     @Test
+    fun `진행 중인 설문은 수정 중인 상태로 변경할 수 있다`() {
+        // given
+        val inProgressSurvey = createSurvey(status = SurveyStatus.IN_PROGRESS, targetParticipantCount = null)
+        val notStartedSurvey = createSurvey(status = SurveyStatus.NOT_STARTED, targetParticipantCount = null)
+        val inModificationSurvey = createSurvey(status = SurveyStatus.IN_MODIFICATION, targetParticipantCount = null)
+        val closedSurvey = createSurvey(status = SurveyStatus.CLOSED, targetParticipantCount = null)
+
+        // when, then
+        assertEquals(SurveyStatus.IN_MODIFICATION, inProgressSurvey.edit().status)
+        assertThrows<InvalidSurveyEditException> { notStartedSurvey.edit() }
+        assertThrows<InvalidSurveyEditException> { inModificationSurvey.edit() }
+        assertThrows<InvalidSurveyEditException> { closedSurvey.edit() }
+    }
+
+    @Test
     fun `설문의 내용를 업데이트할 수 있다`() {
         // given
         val newTitle = "new title"

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -387,32 +387,40 @@ class SurveyTest {
     @Test
     fun `설문을 시작하면, 설문의 시작일과 상태가 업데이트된다`() {
         // given
-        val survey =
+        val notStartedSurvey =
             createSurvey(
                 finishedAt = DateUtil.getDateAfterDay(date = DateUtil.getCurrentDate(noMin = true)),
                 publishedAt = null,
+                targetParticipantCount = null,
                 status = SurveyStatus.NOT_STARTED,
+            )
+        val inModificationSurvey =
+            createSurvey(
+                finishedAt = DateUtil.getDateAfterDay(date = DateUtil.getCurrentDate(noMin = true)),
+                targetParticipantCount = null,
+                status = SurveyStatus.IN_MODIFICATION,
             )
 
         // when
-        val startedSurvey = survey.start()
+        val startedSurvey1 = notStartedSurvey.start()
+        val startedSurvey2 = inModificationSurvey.start()
 
         // then
-        assertEquals(DateUtil.getCurrentDate(), startedSurvey.publishedAt)
-        assertEquals(SurveyStatus.IN_PROGRESS, startedSurvey.status)
+        assertEquals(DateUtil.getCurrentDate(), startedSurvey1.publishedAt)
+        assertEquals(SurveyStatus.IN_PROGRESS, startedSurvey1.status)
+        assertEquals(inModificationSurvey.publishedAt, startedSurvey2.publishedAt)
+        assertEquals(SurveyStatus.IN_PROGRESS, startedSurvey2.status)
     }
 
     @Test
-    fun `설문이 시작 전 상태가 아니면 시작할 수 없다`() {
+    fun `설문이 시작 전 상태나 수정 중인 상태가 아니면 시작할 수 없다`() {
         // given
-        val survey1 = createSurvey(status = SurveyStatus.IN_PROGRESS)
-        val survey2 = createSurvey(status = SurveyStatus.IN_MODIFICATION)
-        val survey3 = createSurvey(status = SurveyStatus.CLOSED)
+        val inProgressSurvey = createSurvey(status = SurveyStatus.IN_PROGRESS)
+        val inModificationSurvey = createSurvey(status = SurveyStatus.CLOSED)
 
         // when, then
-        assertThrows<InvalidSurveyStartException> { survey1.start() }
-        assertThrows<InvalidSurveyStartException> { survey2.start() }
-        assertThrows<InvalidSurveyStartException> { survey3.start() }
+        assertThrows<InvalidSurveyStartException> { inProgressSurvey.start() }
+        assertThrows<InvalidSurveyStartException> { inModificationSurvey.start() }
     }
 
     @Test


### PR DESCRIPTION
## 📢 설명

- 설문을 수정 상태로 변경하는 설문 수정 API 구현([PATCH] `/api/v1/surveys/workbench/edit/{surveyId}`)
    - 설문 관리 페이지의 설문 수정 버튼 클릭 시 호출
- 설문 시작 시 수정 중인 경우도 처리할 수 있도록 수정

## ✅ 체크 리스트

- [x]  진행 중인 설문의 ID로 설문 수정 API([PATCH] `/api/v1/surveys/workbench/edit/{surveyId}`) 호출하여 상태가 `IN_MODIFICATION`으로 잘 변경되는지 확인
- [x]  시작 전, 수정 중, 종료 상태인 설문의 ID로 설문 수정 API 호출 시 아래와 같은 예외가 발생하는지 확인
    
    ```json
    {
      "code": "SV0023",
      "message": "설문 수정 상태 변경에 실패했습니다.",
      "errors": []
    }
    ```
    
- [x]  수정 중인 상태의 설문의 ID로 설문 시작 API 호출 시 정상적으로 상태가 변경되는지 확인
- [x]  설문 생성 API 호출 후 아래 RequestBody로 설문 저장 API 호출(종료일이 작년인 설문)
    
    ```json
    {
      "title": "제목 없는 설문",
      "description": "",
      "thumbnail": null,
      "rewardSetting": {
        "type": "SELF_MANAGEMENT",
        "rewards": [{"name": "a", "category": "b", "count": 1}],
        "targetParticipantCount": null,
        "finishedAt": "2023-11-04T08:00:00.000Z"
      },
      "finishMessage": "설문에 참여해주셔서 감사합니다.",
      "isVisible": true,
      "sections": [
        {
          "sectionId": "2a7bf4e4-7711-4a99-ab21-9b01f2d58312",
          "title": "제목 없는 섹션",
          "description": "",
          "questions": [],
          "routeDetails": {
            "type": "NUMERICAL_ORDER",
            "nextSectionId": null,
            "keyQuestionId": null,
            "sectionRouteConfigs": null
          }
        }
      ]
    }
    ```
    
- [x]  방금 저장한 설문으로 시작 API 호출하여 아래와 같은 예외가 발생하는지 확인
    
    ```json
    {
      "code": "SV0024",
      "message": "설문 마감일이 설문 공개일 보다 빠릅니다.",
      "errors": []
    }
    ```