### PR TITLE
[SBL-138] 설문 결과 API에 설문 정보와 참가자 필터링 기능 추가

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/ResponseAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/ResponseAdapter.kt
@@ -34,8 +34,16 @@ class ResponseAdapter(
             }
         }
 
-    fun getSurveyResult(surveyId: UUID): SurveyResult {
-        val responses = responseRepository.findBySurveyId(surveyId)
+    fun getSurveyResult(
+        surveyId: UUID,
+        participantId: UUID?,
+    ): SurveyResult {
+        val responses =
+            if (participantId != null) {
+                responseRepository.findBySurveyIdAndParticipantId(surveyId, participantId)
+            } else {
+                responseRepository.findBySurveyId(surveyId)
+            }
         // TODO: 추후 DB Level에서 처리하도록 변경 + 필터링을 동적쿼리로 하도록 변경
         val groupingResponses = responses.groupBy { "${it.questionId}|${it.participantId}" }.values
         groupingResponses.map { it.toDomain() }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -53,10 +53,10 @@ class SurveyAdapter(
         surveyRepository.save(surveyDocument)
     }
 
-    fun existsByIdAndMakerId(
+    fun getByIdAndMakerId(
         surveyId: UUID,
-        userId: UUID,
-    ) = surveyRepository.existsByIdAndMakerId(surveyId, userId)
+        makerId: UUID,
+    ) = surveyRepository.findByIdAndMakerId(surveyId, makerId).orElseThrow { SurveyNotFoundException() }.toDomain()
 
     fun getMyPageSurveysInfo(
         makerId: UUID,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResultController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResultController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -22,5 +23,6 @@ class SurveyResultController(
         @PathVariable("survey-id") surveyId: UUID,
         @LoginUser id: UUID,
         @RequestBody surveyResultRequest: SurveyResultRequest,
-    ) = ResponseEntity.ok(surveyResultService.getSurveyResult(surveyId, id, surveyResultRequest))
+        @RequestParam participantId: UUID?,
+    ) = ResponseEntity.ok(surveyResultService.getSurveyResult(surveyId, id, surveyResultRequest, participantId))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResultApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResultApiDoc.kt
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
 
 @Tag(name = "SurveyResult", description = "설문 결과 관련 API")
@@ -19,5 +20,6 @@ interface SurveyResultApiDoc {
         @PathVariable("survey-id") surveyId: UUID,
         @LoginUser id: UUID,
         @RequestBody surveyResultRequest: SurveyResultRequest,
+        @RequestParam participantId: UUID?,
     ): ResponseEntity<SurveyResultResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/result/SurveyResult.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/result/SurveyResult.kt
@@ -16,6 +16,8 @@ data class SurveyResult(
         return filteredSurveyResult
     }
 
+    fun findResultDetailsByQuestionId(questionId: UUID) = resultDetails.filter { it.questionId == questionId }
+
     private fun filterByQuestionFilter(questionFilter: QuestionFilter): SurveyResult {
         val participantSet = getMatchedParticipants(questionFilter)
         return if (questionFilter.isPositive) {

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyResultResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyResultResponse.kt
@@ -1,38 +1,76 @@
 package com.sbl.sulmun2yong.survey.dto.response
 
+import com.sbl.sulmun2yong.survey.domain.Survey
+import com.sbl.sulmun2yong.survey.domain.question.Question
+import com.sbl.sulmun2yong.survey.domain.question.QuestionType
 import com.sbl.sulmun2yong.survey.domain.result.ResultDetails
 import com.sbl.sulmun2yong.survey.domain.result.SurveyResult
+import com.sbl.sulmun2yong.survey.domain.section.Section
 import java.util.UUID
 
 data class SurveyResultResponse(
-    val results: List<Result>,
+    val sectionResults: List<SectionResultResponse>,
 ) {
     companion object {
-        fun of(surveyResult: SurveyResult) =
-            SurveyResultResponse(
-                results =
-                    surveyResult.resultDetails.groupBy { it.questionId }.map {
-                        Result.from(it.value)
-                    },
-            )
+        fun of(
+            surveyResult: SurveyResult,
+            survey: Survey,
+        ) = SurveyResultResponse(survey.sections.map { SectionResultResponse.of(surveyResult, it) })
     }
 
-    data class Result(
+    data class SectionResultResponse(
+        val sectionId: UUID,
+        val title: String,
+        val questionResults: List<QuestionResultResponse>,
+    ) {
+        companion object {
+            fun of(
+                surveyResult: SurveyResult,
+                section: Section,
+            ): SectionResultResponse =
+                SectionResultResponse(
+                    sectionId = section.id.value,
+                    title = section.title,
+                    questionResults =
+                        section.questions.map {
+                            QuestionResultResponse.of(
+                                question = it,
+                                responses = surveyResult.findResultDetailsByQuestionId(it.id),
+                            )
+                        },
+                )
+        }
+    }
+
+    data class QuestionResultResponse(
         val questionId: UUID,
+        val title: String,
+        val type: QuestionType,
+        val participantCount: Int,
         val responses: List<Response>,
     ) {
         companion object {
-            fun from(responses: List<ResultDetails>): Result =
-                Result(
-                    questionId = responses.first().questionId,
-                    responses =
-                        responses
-                            .map { it.contents }
-                            .flatten()
-                            .groupingBy { it }
-                            .eachCount()
-                            .map { Response(it.key, it.value) },
+            fun of(
+                question: Question,
+                responses: List<ResultDetails>,
+            ): QuestionResultResponse {
+                val contentCountMap =
+                    responses
+                        .map { it.contents }
+                        .flatten()
+                        .groupingBy { it }
+                        .eachCount()
+                        .toMutableMap()
+                val contents = question.choices?.standardChoices?.map { it.content } ?: emptyList()
+                contents.forEach { contentCountMap.putIfAbsent(it, 0) }
+                return QuestionResultResponse(
+                    questionId = question.id,
+                    title = question.title,
+                    type = question.questionType,
+                    participantCount = responses.size,
+                    responses = contentCountMap.map { Response(it.key, it.value) },
                 )
+            }
         }
 
         data class Response(

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/ResponseRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/ResponseRepository.kt
@@ -8,4 +8,9 @@ import java.util.UUID
 @Repository
 interface ResponseRepository : MongoRepository<ResponseDocument, UUID> {
     fun findBySurveyId(surveyId: UUID): List<ResponseDocument>
+
+    fun findBySurveyIdAndParticipantId(
+        surveyId: UUID,
+        participantId: UUID,
+    ): List<ResponseDocument>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 import java.util.UUID
 
 @Repository
@@ -17,8 +18,8 @@ interface SurveyRepository :
         pageable: Pageable,
     ): Page<SurveyDocument>
 
-    fun existsByIdAndMakerId(
-        surveyId: UUID,
-        userId: UUID,
-    ): Boolean
+    fun findByIdAndMakerId(
+        id: UUID,
+        makerId: UUID,
+    ): Optional<SurveyDocument>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResultService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResultService.kt
@@ -4,7 +4,6 @@ import com.sbl.sulmun2yong.survey.adapter.ResponseAdapter
 import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResultRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyResultResponse
-import com.sbl.sulmun2yong.survey.exception.SurveyNotFoundException
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -15,19 +14,18 @@ class SurveyResultService(
 ) {
     fun getSurveyResult(
         surveyId: UUID,
-        userId: UUID,
+        makerId: UUID,
         surveyResultRequest: SurveyResultRequest,
+        participantId: UUID?,
     ): SurveyResultResponse {
-        val isSurveyExists = surveyAdapter.existsByIdAndMakerId(surveyId, userId)
-        // 본인이 만든 설문이 아닌 경우 예외 발생
-        if (!isSurveyExists) throw SurveyNotFoundException()
+        val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
 
         // DB에서 설문 결과 조회
-        val surveyResult = responseAdapter.getSurveyResult(surveyId)
+        val surveyResult = responseAdapter.getSurveyResult(surveyId, participantId)
 
         // 요청에 따라 설문 결과 필터링
         val resultFilter = surveyResultRequest.toDomain()
         val filteredSurveyResult = surveyResult.getFilteredResult(resultFilter)
-        return SurveyResultResponse.of(filteredSurveyResult)
+        return SurveyResultResponse.of(filteredSurveyResult, survey)
     }
 }

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/result/SurveyResultTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/result/SurveyResultTest.kt
@@ -1,6 +1,7 @@
 package com.sbl.sulmun2yong.survey.domain.result
 
 import com.sbl.sulmun2yong.fixture.survey.SurveyResultConstFactory.EXCEPT_STUDENT_FILTER
+import com.sbl.sulmun2yong.fixture.survey.SurveyResultConstFactory.JOB_QUESTION_ID
 import com.sbl.sulmun2yong.fixture.survey.SurveyResultConstFactory.K_J_FOOD_FILTER
 import com.sbl.sulmun2yong.fixture.survey.SurveyResultConstFactory.MAN_FILTER
 import com.sbl.sulmun2yong.fixture.survey.SurveyResultConstFactory.PARTICIPANT_RESULT_DETAILS_1
@@ -156,6 +157,23 @@ class SurveyResultTest {
         with(filteredResult3.resultDetails) {
             assertEquals(12, size)
             assertTrue { this.containsAll(PARTICIPANT_RESULT_DETAILS_2) }
+        }
+    }
+
+    @Test
+    fun `설문 결과는 질문 ID를 받으면 해당 질문의 응답들만 반환한다`() {
+        // given
+        val surveyResult = SURVEY_RESULT
+
+        // when
+        val jobQuestionResponses = surveyResult.findResultDetailsByQuestionId(JOB_QUESTION_ID)
+
+        // then
+        assertEquals(3, jobQuestionResponses.size)
+        with(jobQuestionResponses.map { it.contents }.flatten()) {
+            assertEquals(true, containsAll(PARTICIPANT_RESULT_DETAILS_1[0].contents))
+            assertEquals(true, containsAll(PARTICIPANT_RESULT_DETAILS_2[0].contents))
+            assertEquals(true, containsAll(PARTICIPANT_RESULT_DETAILS_3[0].contents))
         }
     }
 }


### PR DESCRIPTION
## 📢 설명
- 설문 결과 API의 응답을 섹션별로 묶도록 수정
- 설문 결과 API의 응답을 각 섹션과 질문의 제목, 질문의 다른 정보(유형, 참여자 수)를 함께 주도록 수정
- 설문 결과 API에 쿼리 스트링 으로 participantId를 추가하여 참가자를 필터링 할 수 있도록 수정

## ✅ 체크 리스트
- [x]  설문 결과 API 호출 시 아래와 같은 형식으로 응답이 오는지 확인
    
    ```json
    {
      "sectionResults": [
        {
          "sectionId": "2fa85f64-5717-4562-b3fc-2c963f660000",
          "title": "섹션 제목",
          "questionResults": [
            {
              "questionId": "3fa85f64-5717-4562-b3fc-2c963f660000",
              "title": "질문 제목",
              "type": "ENUM(TEXT_RESPONSE, SINGLE_CHOICE, MULTIPLE_CHOICE)",
              "participantCount": 10,
              "responses": [
                {
                  "content": "학생",
                  "count": 2
                },
                {
                  "content": "직장인",
                  "count": 1
                },
                {
                  "content": "자영업자",
                  "count": 1
                },
                {
                  "content": "백수",
                  "count": 0
                }
              ]
            }
          ]
        }
      ]
    }
    ```
- [x] QueryString으로 participantId를 주었을 때 해당 참가자의 응답만 오는지 확인
