### PR TITLE
[SBL-157] 설문 종료 API 구현, 설문 결과 API 참가자 수 로직 수정

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -55,4 +55,10 @@ class SurveyManagementController(
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ) = ResponseEntity.ok(surveyManagementService.editSurvey(surveyId = surveyId, makerId = id))
+
+    @PatchMapping("/finish/{surveyId}")
+    override fun finishSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ) = ResponseEntity.ok(surveyManagementService.finishSurvey(surveyId = surveyId, makerId = id))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -51,4 +51,11 @@ interface SurveyManagementApiDoc {
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ): ResponseEntity<Unit>
+
+    @Operation(summary = "설문 종료 API")
+    @PatchMapping("/finish/{surveyId}")
+    fun finishSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyResultResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyResultResponse.kt
@@ -17,7 +17,8 @@ data class SurveyResultResponse(
         fun of(
             surveyResult: SurveyResult,
             survey: Survey,
-        ) = SurveyResultResponse(survey.sections.map { SectionResultResponse.of(surveyResult, it) }, surveyResult.getParticipantCount())
+            participantCount: Int,
+        ) = SurveyResultResponse(survey.sections.map { SectionResultResponse.of(surveyResult, it) }, participantCount)
     }
 
     data class SectionResultResponse(

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyResultResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyResultResponse.kt
@@ -34,11 +34,7 @@ data class SurveyResultResponse(
                 SectionResultResponse(
                     sectionId = section.id.value,
                     title = section.title,
-                    questionResults =
-                        section.questions.mapNotNull { question ->
-                            val questionResult = surveyResult.findQuestionResult(question.id)
-                            questionResult?.let { QuestionResultResponse.of(question, it) }
-                        },
+                    questionResults = section.questions.map { QuestionResultResponse.of(it, surveyResult.findQuestionResult(it.id)) },
                 )
         }
     }
@@ -54,8 +50,19 @@ data class SurveyResultResponse(
         companion object {
             fun of(
                 question: Question,
-                questionResult: QuestionResult,
+                questionResult: QuestionResult?,
             ): QuestionResultResponse {
+                if (questionResult == null) {
+                    return QuestionResultResponse(
+                        questionId = question.id,
+                        title = question.title,
+                        type = question.questionType,
+                        participantCount = 0,
+                        responses = listOf(),
+                        responseContents = question.choices?.standardChoices?.map { it.content } ?: listOf(),
+                    )
+                }
+
                 val allContents =
                     if (question is ChoiceQuestion) {
                         val tempContents = question.choices.standardChoices.map { it.content }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -87,4 +87,12 @@ class SurveyManagementService(
         if (survey.makerId != makerId) throw InvalidSurveyAccessException()
         surveyAdapter.save(survey.edit())
     }
+
+    fun finishSurvey(
+        surveyId: UUID,
+        makerId: UUID,
+    ) {
+        val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
+        surveyAdapter.save(survey.finish())
+    }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -8,7 +8,6 @@ import com.sbl.sulmun2yong.survey.domain.reward.ImmediateDrawSetting
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyCreateResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
-import com.sbl.sulmun2yong.survey.exception.InvalidSurveyAccessException
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -29,9 +28,7 @@ class SurveyManagementService(
         surveySaveRequest: SurveySaveRequest,
         makerId: UUID,
     ) {
-        val survey = surveyAdapter.getSurvey(surveyId)
-        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
-        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
+        val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
         val newSurvey =
             with(surveySaveRequest) {
                 survey.updateContent(
@@ -51,9 +48,7 @@ class SurveyManagementService(
         surveyId: UUID,
         makerId: UUID,
     ): SurveyMakeInfoResponse {
-        val survey = surveyAdapter.getSurvey(surveyId)
-        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
-        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
+        val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
         return SurveyMakeInfoResponse.of(survey)
     }
 
@@ -62,9 +57,7 @@ class SurveyManagementService(
         surveyId: UUID,
         makerId: UUID,
     ) {
-        val survey = surveyAdapter.getSurvey(surveyId)
-        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
-        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
+        val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
         val startedSurvey = survey.start()
         surveyAdapter.save(startedSurvey)
         if (startedSurvey.rewardSetting is ImmediateDrawSetting) {
@@ -82,9 +75,7 @@ class SurveyManagementService(
         surveyId: UUID,
         makerId: UUID,
     ) {
-        val survey = surveyAdapter.getSurvey(surveyId)
-        // 현재 유저와 설문 제작자가 다를 경우 예외 발생
-        if (survey.makerId != makerId) throw InvalidSurveyAccessException()
+        val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
         surveyAdapter.save(survey.edit())
     }
 


### PR DESCRIPTION
## 📢 설명
- 설문 종료 API 구현
  - [PATCH] /api/v1/survey/finish/{survey-id}
- 설문 결과 API 참가자 수 로직 수정
  - 참가자 수를 구할 때 필터가 없는 경우 필터링된 참가자 수 대신 Participant Document의 참가자 수를 주도록 수정
  - 이렇게 수정한 이유는, 질문이 없는 설문은 참여를 해도 응답이 없어서 응답자 수가 0이 나오기 때문

    <img width="363" alt="image" src="https://github.com/user-attachments/assets/27b43b30-1908-4665-85bd-11f11afaf89e">
    <img width="304" alt="image" src="https://github.com/user-attachments/assets/5cb4e600-1e16-4710-ad23-e1982c073243">

## ✅ 체크 리스트

- [x]  테스트용으로 질문이 하나도 없고, 참가자가 있는 설문 생성
    - [x]  설문 생성 API 호출, 아래 RequestBody로 설문 저장 API 호출, 설문 시작 API 호출
        
        ```json
        {
          "title": "0926 테스트 설문",
          "description": "",
          "thumbnail": null,
          "rewardSetting": {
            "type": "NO_REWARD",
            "rewards": [],
            "targetParticipantCount": null,
            "finishedAt": null
          },
          "finishMessage": "설문에 참여해주셔서 감사합니다.",
          "isVisible": true,
          "sections": [
            {
              "sectionId": "5a6f989d-5062-4d1d-8f69-30535ed5f8a4",
              "title": "제목 없는 섹션",
              "description": "",
              "questions": [],
              "routeDetails": {
                "type": "NUMERICAL_ORDER",
                "nextSectionId": null,
                "keyQuestionId": null,
                "sectionRouteConfigs": null
              }
            }
          ]
        }
        ```
        
    - [x]  아래 RequestBody로 설문 응답 API 여러번 호출
        
        ```json
        {
          "sectionResponses": [
            {
              "sectionId": "5a6f989d-5062-4d1d-8f69-30535ed5f8a4",
              "questionResponses": []
            }
          ]
        }
        ```
        
- [x]  방금 만든 테스트용 설문으로 아래 RequestBody를 이용하여 설문 결과 API를 호출하였을 때 참가자 수(`participantCount`**)**가 정상적으로 표시되는지 확인
    
    ```json
    {
      "questionFilters": []
    }
    ```
    
- [x]  방금 만든 테스트용 설문으로 설문 수정 API 호출, 아래 RequestBody로 설문 저장 API 호출, 설문 시작 API 호출
    
    ```json
    {
      "title": "0926 테스트 설문",
      "description": "",
      "thumbnail": null,
      "rewardSetting": {
        "type": "NO_REWARD",
        "rewards": [],
        "targetParticipantCount": null,
        "finishedAt": null
      },
      "finishMessage": "설문에 참여해주셔서 감사합니다.",
      "isVisible": true,
      "sections": [
        {
          "sectionId": "5a6f989d-5062-4d1d-8f69-30535ed5f8a4",
          "title": "제목 없는 섹션",
          "description": "",
          "questions": [
            {
              "questionId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
              "type": "SINGLE_CHOICE",
              "title": "string",
              "description": "string",
              "isRequired": true,
              "isAllowOther": false,
              "choices": [
                "1",
                "2",
                "3"
              ]
            }
          ],
          "routeDetails": {
            "type": "NUMERICAL_ORDER",
            "nextSectionId": null,
            "keyQuestionId": null,
            "sectionRouteConfigs": null
          }
        }
      ]
    }
    ```
    
    - 질문이 하나도 없다가, 질문이 하나 생긴 경우에 문제가 없는지 확인하기 위함
- [x]  방금 만든 테스트용 설문으로 아래 RequestBody를 이용하여 설문 결과 API를 호출하였을 때 참가자 수(`participantCount`**)**가 정상적으로 표시되는지 확인
    
    ```json
    {
      "questionFilters": []
    }
    ```
    
- [x]  아래 RequestBody로 설문 결과 API를 호출하였을 때 아래 ResponseBody 처럼 응답이 오는지 확인
    - RequestBody
        
        ```json
        {
          "questionFilters": [
            {
              "questionId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
              "contents": [
                "1",
                "2",
                "3"
              ],
              "isPositive": true
            }
          ]
        }
        ```
        
    - ResponseBody
        
        ```json
        {
          "sectionResults": [
            {
              "sectionId": "5a6f989d-5062-4d1d-8f69-30535ed5f8a4",
              "title": "제목 없는 섹션",
              "questionResults": [
                {
                  "questionId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
                  "title": "string",
                  "type": "SINGLE_CHOICE",
                  "participantCount": 0,
                  "responses": [],
                  "responseContents": [
                    "1",
                    "2",
                    "3"
                  ]
                }
              ]
            }
          ],
          "participantCount": 0
        }
        ```
        
- [x]  설문 종료 API를 호출하여 설문이 `CLOSED` 상태가 되는지 확인