### PR TITLE
[SBL-165] MongoDB 스키마 버전 관리를 위한 Mongock 초기 세팅

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,10 @@ dependencies {
     // mongoDB
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
 
+    // mongock
+    implementation("io.mongock:mongock-springboot:5.4.4")
+    implementation("io.mongock:mongodb-springdata-v4-driver:5.4.4")
+
     // validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/MongockConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/MongockConfig.kt
@@ -1,0 +1,8 @@
+package com.sbl.sulmun2yong.global.config
+
+import io.mongock.runner.springboot.EnableMongock
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableMongock
+class MongockConfig

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/migration/InitialMongoDBSetUp.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/migration/InitialMongoDBSetUp.kt
@@ -1,0 +1,47 @@
+package com.sbl.sulmun2yong.global.migration
+
+import com.sbl.sulmun2yong.global.error.GlobalExceptionHandler
+import io.mongock.api.annotations.ChangeUnit
+import io.mongock.api.annotations.Execution
+import io.mongock.api.annotations.RollbackExecution
+import org.slf4j.LoggerFactory
+import org.springframework.data.mongodb.core.MongoTemplate
+
+@ChangeUnit(id = "InitialMongoDBSetUp", order = "001", author = "hunhui")
+class InitialMongoDBSetUp {
+    companion object {
+        private const val SURVEY_COLLECTION = "surveys"
+        private const val DRAWING_BOARD_COLLECTION = "drawingBoards"
+        private const val DRAWING_HISTORY_COLLECTION = "drawingHistories"
+        private const val PARTICIPANT_COLLECTION = "participants"
+        private const val RESPONSE_COLLECTION = "responses"
+        private const val USER_COLLECTION = "users"
+        val COLLECTIONS =
+            listOf(
+                SURVEY_COLLECTION,
+                DRAWING_BOARD_COLLECTION,
+                DRAWING_HISTORY_COLLECTION,
+                PARTICIPANT_COLLECTION,
+                RESPONSE_COLLECTION,
+                USER_COLLECTION,
+            )
+    }
+
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @Execution
+    fun initialSetup(mongoTemplate: MongoTemplate) {
+        val collectionNames = mongoTemplate.db.listCollectionNames().toList()
+        for (collection in COLLECTIONS) {
+            if (!collectionNames.contains(collection)) {
+                mongoTemplate.db.createCollection(collection)
+            }
+        }
+        log.info("001-InitialMongoDBSetUp 완료")
+    }
+
+    @RollbackExecution
+    fun rollback() {
+        log.warn("001-InitialMongoDBSetUp 롤백")
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/migration/InitialMongoDBSetUp.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/migration/InitialMongoDBSetUp.kt
@@ -7,6 +7,7 @@ import io.mongock.api.annotations.RollbackExecution
 import org.slf4j.LoggerFactory
 import org.springframework.data.mongodb.core.MongoTemplate
 
+/** 최초에 컬렉션들을 생성하는 Migration Class */
 @ChangeUnit(id = "InitialMongoDBSetUp", order = "001", author = "hunhui")
 class InitialMongoDBSetUp {
     companion object {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,7 @@ ai-server:
 
 cloudfront:
     base-url: https://files.sulmoon.io
+
+mongock:
+    enabled: true
+    migration-scan-package: com.sbl.sulmun2yong.global.migration


### PR DESCRIPTION
## 📢 설명

- MongoDB 스키마 버전 관리를 위한 Mongock 초기 세팅 완료

## 📢 Mongock 도입 이유

- 지속적으로 개발을 진행하다 보니 스키마가 자주 변경되고, 이를 개발 서버와 운영 서버에 적용하기 어려워짐
- 이러한 문제를 해결하기 위해 MongoDB 스키마 버전 관리 도구인 Mongock 도입

## 📢 Mongock 설명

- 공식 문서: https://docs.mongock.io/index.html
- 아래와 같이 코드를 작성하면, `InitialMongoDBSetUp`이 실행되지 않은 경우 `@Execution`이 붙은 메서드들을 실행한다. 이렇게 실행된 작업 내용은 `mongockChangeLog` 컬렉션에 기록된다. (`mongockChangeLog`는 Mongock이 알아서 관리함)
    
    ```kotlin
    package com.sbl.sulmun2yong.global.migration
    
    import ...
    
    /** 최초에 컬렉션들을 생성하는 Migration Class */
    @ChangeUnit(id = "InitialMongoDBSetUp", order = "001", author = "hunhui")
    class InitialMongoDBSetUp {
        @Execution
        fun initialSetup(mongoTemplate: MongoTemplate) {
            val collectionNames = mongoTemplate.db.listCollectionNames().toList()
            for (collection in COLLECTIONS) {
                if (!collectionNames.contains(collection)) {
                    mongoTemplate.db.createCollection(collection)
                }
            }
            log.info("001-InitialMongoDBSetUp 완료")
        }
    
        /** @Execution이 붙은 메서드 실행 중 예외 발생 시 실행할 메서드 */
        @RollbackExecution
        fun rollback() {
            log.warn("001-InitialMongoDBSetUp 롤백")
        }
    }
    
    ```
    
- 이러한 Migration Class들은 application.yml에 정의한 `mongock.migration-scan-package`에 모아두어야한다.
    
    ```yaml
    mongock:
        migration-scan-package: com.sbl.sulmun2yong.global.migration
    ```
    
- 추후에 스키마가 변경되는 경우 아래와 같이 추가적인 Migration Class를 application.yml에 정의한 `migration-scan-package`에 추가로 생성하면 된다.
    
    ```kotlin
    package com.sbl.sulmun2yong.global.migration
    
    import ...
    
    /** Surveys 컬렉션의 isDelete가 null인 경우 기본값 false를 넣는 Migration Class */
    @ChangeUnit(id = "AddIsDeletedFieldAtSurveyDocument", order = "002", author = "hunhui")
    class AddIsDeletedFieldAtSurveyDocument {
        private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
    
        @Execution
        fun addIsDeletedField(mongoTemplate: MongoTemplate) {
            val query = Query(Criteria.where("isDeleted").`is`(null))
            val update = Update().set("isDeleted", false)
            mongoTemplate.updateMulti(query, update, SurveyDocument::class.java)
            log.info("002-AddIsDeletedFieldAtSurveyDocument 완료")
        }
    
        @RollbackExecution
        fun rollback() {
            log.warn("002-AddIsDeletedFieldAtSurveyDocument 롤백")
        }
    }
    ```
    

## ✅ 체크 리스트

- [x]  어플리케이션 실행 시 `001-InitialMongoDBSetUp 완료`로그가 출력되는지 확인
- [x]  어플리케이션 재시작 시 `001-InitialMongoDBSetUp 완료`로그가 출력되지 않는지 확인(한 번만 실행되어야 하므로 재시작 시 출력되지 않는 것이 정상)
- [x]  MongoDB에서 mongockChangeLog 컬렉션을 제거하고, `com.sbl.sulmun2yong.global.migration.InitialMongoDBSetUp.kt`의 `initialSetup` 메서드를 아래와 같이 수정한 뒤 어플리케이션을 실행했을 때 `001-InitialMongoDBSetUp 롤백`로그가 출력되는지 확인
    
    ```kotlin
        @Execution
        fun initialSetup(mongoTemplate: MongoTemplate) {
            val collectionNames = mongoTemplate.db.listCollectionNames().toList()
            for (collection in COLLECTIONS) {
                if (!collectionNames.contains(collection)) {
                    mongoTemplate.db.createCollection(collection)
                }
            }
            throw RuntimeException("강제로 롤백") // 예외를 발생시켜 강제로 롤백
            log.info("001-InitialMongoDBSetUp 완료")
        }
    ```