### PR TITLE
[SBL-131] 설문 삭제 API 구현, softDelete 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/migration/AddIsDeletedFieldAtSurveyDocument.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/migration/AddIsDeletedFieldAtSurveyDocument.kt
@@ -1,0 +1,31 @@
+package com.sbl.sulmun2yong.global.migration
+
+import com.sbl.sulmun2yong.global.error.GlobalExceptionHandler
+import com.sbl.sulmun2yong.survey.entity.SurveyDocument
+import io.mongock.api.annotations.ChangeUnit
+import io.mongock.api.annotations.Execution
+import io.mongock.api.annotations.RollbackExecution
+import org.slf4j.LoggerFactory
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+
+/** Surveys 컬렉션의 isDelete가 null인 경우 기본값 false를 넣는 Migration Class */
+@ChangeUnit(id = "AddIsDeletedFieldAtSurveyDocument", order = "002", author = "hunhui")
+class AddIsDeletedFieldAtSurveyDocument {
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @Execution
+    fun addIsDeletedField(mongoTemplate: MongoTemplate) {
+        val query = Query(Criteria.where("isDeleted").`is`(null))
+        val update = Update().set("isDeleted", false)
+        mongoTemplate.updateMulti(query, update, SurveyDocument::class.java)
+        log.info("002-AddIsDeletedFieldAtSurveyDocument 완료")
+    }
+
+    @RollbackExecution
+    fun rollback() {
+        log.warn("002-AddIsDeletedFieldAtSurveyDocument 롤백")
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -64,4 +64,12 @@ class SurveyAdapter(
         status: SurveyStatus?,
         sortType: MySurveySortType,
     ) = surveyRepository.findSurveysWithResponseCount(makerId, status, sortType)
+
+    fun delete(
+        surveyId: UUID,
+        makerId: UUID,
+    ) {
+        val isSuccess = surveyRepository.softDelete(surveyId, makerId)
+        if (!isSuccess) throw SurveyNotFoundException()
+    }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -25,12 +25,13 @@ class SurveyAdapter(
         isAsc: Boolean,
     ): Page<Survey> {
         val pageRequest = PageRequest.of(page, size, getSurveySort(sortType, isAsc))
-        val surveyDocuments = surveyRepository.findByStatusAndIsVisibleTrue(SurveyStatus.IN_PROGRESS, pageRequest)
+        val surveyDocuments = surveyRepository.findByStatusAndIsVisibleTrueAndIsDeletedFalse(SurveyStatus.IN_PROGRESS, pageRequest)
         val surveys = surveyDocuments.content.map { it.toDomain() }
         return PageImpl(surveys, pageRequest, surveyDocuments.totalElements)
     }
 
-    fun getSurvey(surveyId: UUID) = surveyRepository.findById(surveyId).orElseThrow { SurveyNotFoundException() }.toDomain()
+    fun getSurvey(surveyId: UUID) =
+        surveyRepository.findByIdAndIsDeletedFalse(surveyId).orElseThrow { SurveyNotFoundException() }.toDomain()
 
     private fun getSurveySort(
         sortType: SurveySortType,
@@ -46,7 +47,7 @@ class SurveyAdapter(
     }
 
     fun save(survey: Survey) {
-        val previousSurveyDocument = surveyRepository.findById(survey.id)
+        val previousSurveyDocument = surveyRepository.findByIdAndIsDeletedFalse(survey.id)
         val surveyDocument = SurveyDocument.from(survey)
         // 기존 설문을 업데이트하는 경우, createdAt을 유지
         if (previousSurveyDocument.isPresent) surveyDocument.createdAt = previousSurveyDocument.get().createdAt
@@ -56,7 +57,7 @@ class SurveyAdapter(
     fun getByIdAndMakerId(
         surveyId: UUID,
         makerId: UUID,
-    ) = surveyRepository.findByIdAndMakerId(surveyId, makerId).orElseThrow { SurveyNotFoundException() }.toDomain()
+    ) = surveyRepository.findByIdAndMakerIdAndIsDeletedFalse(surveyId, makerId).orElseThrow { SurveyNotFoundException() }.toDomain()
 
     fun getMyPageSurveysInfo(
         makerId: UUID,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -5,6 +5,7 @@ import com.sbl.sulmun2yong.survey.controller.doc.SurveyManagementApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveySaveRequest
 import com.sbl.sulmun2yong.survey.service.SurveyManagementService
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -61,4 +62,10 @@ class SurveyManagementController(
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ) = ResponseEntity.ok(surveyManagementService.finishSurvey(surveyId = surveyId, makerId = id))
+
+    @DeleteMapping("/delete/{surveyId}")
+    override fun deleteSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ) = ResponseEntity.ok(surveyManagementService.deleteSurvey(surveyId = surveyId, makerId = id))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -7,6 +7,7 @@ import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -55,6 +56,13 @@ interface SurveyManagementApiDoc {
     @Operation(summary = "설문 종료 API")
     @PatchMapping("/finish/{surveyId}")
     fun finishSurvey(
+        @PathVariable("surveyId") surveyId: UUID,
+        @LoginUser id: UUID,
+    ): ResponseEntity<Unit>
+
+    @Operation(summary = "설문 삭제 API")
+    @DeleteMapping("/delete/{surveyId}")
+    fun deleteSurvey(
         @PathVariable("surveyId") surveyId: UUID,
         @LoginUser id: UUID,
     ): ResponseEntity<Unit>

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/entity/SurveyDocument.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/entity/SurveyDocument.kt
@@ -40,6 +40,7 @@ data class SurveyDocument(
     val makerId: UUID,
     val rewards: List<RewardSubDocument>,
     val sections: List<SectionSubDocument>,
+    val isDeleted: Boolean = false,
 ) : BaseTimeDocument() {
     companion object {
         fun from(survey: Survey) =
@@ -151,15 +152,8 @@ data class SurveyDocument(
         val isAllowOther: Boolean,
     )
 
-    fun toDomain(): Survey {
-        val sections =
-            if (this.sections.isEmpty()) {
-                listOf()
-            } else {
-                val sectionIds = SectionIds.from(this.sections.map { SectionId.Standard(it.sectionId) })
-                this.sections.map { it.toDomain(sectionIds) }
-            }
-        return Survey(
+    fun toDomain(): Survey =
+        Survey(
             id = this.id,
             title = this.title,
             description = this.description,
@@ -179,7 +173,6 @@ data class SurveyDocument(
             makerId = this.makerId,
             sections = this.sections.toDomain(),
         )
-    }
 
     private fun List<SectionSubDocument>.toDomain() =
         if (this.isEmpty()) {

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepository.kt
@@ -11,4 +11,9 @@ interface SurveyCustomRepository {
         status: SurveyStatus?,
         sortType: MySurveySortType,
     ): List<MyPageSurveyInfoResponse>
+
+    fun softDelete(
+        surveyId: UUID,
+        makerId: UUID,
+    ): Boolean
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
@@ -19,7 +19,7 @@ class SurveyCustomRepositoryImpl(
     ): List<MyPageSurveyInfoResponse> {
         val matchStage =
             Aggregation.match(
-                Criteria.where("makerId").`is`(makerId).apply {
+                Criteria.where("makerId").`is`(makerId).and("isDeleted").`is`(false).apply {
                     status?.let { and("status").`is`(it) }
                 },
             )

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
@@ -3,10 +3,13 @@ package com.sbl.sulmun2yong.survey.repository
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import com.sbl.sulmun2yong.survey.dto.request.MySurveySortType
 import com.sbl.sulmun2yong.survey.dto.response.MyPageSurveyInfoResponse
+import com.sbl.sulmun2yong.survey.entity.SurveyDocument
 import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.aggregation.Aggregation
 import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
 import java.util.UUID
 
 class SurveyCustomRepositoryImpl(
@@ -38,6 +41,26 @@ class SurveyCustomRepositoryImpl(
 
         val results = mongoTemplate.aggregate(aggregation, "surveys", MyPageSurveyInfoResponse::class.java)
         return results.mappedResults
+    }
+
+    override fun softDelete(
+        surveyId: UUID,
+        makerId: UUID,
+    ): Boolean {
+        val query =
+            Query(
+                Criteria
+                    .where("_id")
+                    .`is`(surveyId)
+                    .and("makerId")
+                    .`is`(makerId),
+            )
+        val update = Update().set("isDeleted", true)
+
+        val result = mongoTemplate.updateFirst(query, update, SurveyDocument::class.java)
+
+        // 변경된 문서가 있을 경우 true, 없을 경우 false 반환
+        return result.modifiedCount > 0
     }
 
     private fun MySurveySortType.toSort() =

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyRepository.kt
@@ -13,13 +13,15 @@ import java.util.UUID
 interface SurveyRepository :
     MongoRepository<SurveyDocument, UUID>,
     SurveyCustomRepository {
-    fun findByStatusAndIsVisibleTrue(
+    fun findByStatusAndIsVisibleTrueAndIsDeletedFalse(
         status: SurveyStatus,
         pageable: Pageable,
     ): Page<SurveyDocument>
 
-    fun findByIdAndMakerId(
+    fun findByIdAndMakerIdAndIsDeletedFalse(
         id: UUID,
         makerId: UUID,
     ): Optional<SurveyDocument>
+
+    fun findByIdAndIsDeletedFalse(id: UUID): Optional<SurveyDocument>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -88,4 +88,11 @@ class SurveyManagementService(
         val survey = surveyAdapter.getByIdAndMakerId(surveyId, makerId)
         surveyAdapter.save(survey.finish())
     }
+
+    fun deleteSurvey(
+        surveyId: UUID,
+        makerId: UUID,
+    ) {
+        surveyAdapter.delete(surveyId, makerId)
+    }
 }


### PR DESCRIPTION
## 📢 설명

- surveys 컬렉션에 isDeleted 컬럼 추가
- 기존 설문 조회 쿼리에 isDeleted가 false인지 확인하는 조건 추가
- 설문 삭제 API 구현 ([DELETE] `/api/v1/surveys/workbench/delete/{surveyId}`)
- 기존 surveys 컬렉션에 isDeleted를 false로 넣는 migration 코드 추가

## ✅ 체크 리스트

- [x]  애플리케이션 시작 시 DB에 접속해서 surveys 컬렉션의 기존 설문들의 isDeleted가 false로 되어있는지 확인
- [x]  설문 삭제 API를 호출하여 200 응답이 오는지 확인
- [x]  설문 목록 API, 설문 제작 정보 API, 설문 정보 조회 API, 마이페이지 설문 목록 조회 API 호출 시 삭제한 설문이 조회가 안되는지 확인