### PR TITLE
[SBL-130] 설문 종료 스케줄러 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/SchedulingConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.sbl.sulmun2yong.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Component
+import java.util.Date
 import java.util.UUID
 
 @Component
@@ -71,5 +72,11 @@ class SurveyAdapter(
     ) {
         val isSuccess = surveyRepository.softDelete(surveyId, makerId)
         if (!isSuccess) throw SurveyNotFoundException()
+    }
+
+    fun findFinishTargets(now: Date) = surveyRepository.findFinishTargets(now).map { it.toDomain() }
+
+    fun saveAll(surveys: List<Survey>) {
+        surveyRepository.saveAll(surveys.map { SurveyDocument.from(it) })
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyRepository.kt
@@ -5,7 +5,9 @@ import com.sbl.sulmun2yong.survey.entity.SurveyDocument
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.mongodb.repository.Query
 import org.springframework.stereotype.Repository
+import java.util.Date
 import java.util.Optional
 import java.util.UUID
 
@@ -24,4 +26,7 @@ interface SurveyRepository :
     ): Optional<SurveyDocument>
 
     fun findByIdAndIsDeletedFalse(id: UUID): Optional<SurveyDocument>
+
+    @Query("{ 'finishedAt': { \$lt: ?0 }, 'status': { \$in: ['IN_PROGRESS', 'IN_MODIFICATION'] }, 'isDeleted': false }")
+    fun findFinishTargets(now: Date): List<SurveyDocument>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/scheduler/SurveyFinishScheduler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/scheduler/SurveyFinishScheduler.kt
@@ -13,7 +13,7 @@ class SurveyFinishScheduler(
 ) {
     private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
-    @Scheduled(cron = "0 * * * * *") // 매 시 정각에 실행
+    @Scheduled(cron = "0 0 * * * *") // 매 시 정각에 실행
     fun closeExpiredSurveys() {
         val targetSurveys = surveyAdapter.findFinishTargets(Date())
         val finishedTargetSurveys =

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/scheduler/SurveyFinishScheduler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/scheduler/SurveyFinishScheduler.kt
@@ -1,0 +1,29 @@
+package com.sbl.sulmun2yong.survey.scheduler
+
+import com.sbl.sulmun2yong.global.error.GlobalExceptionHandler
+import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.util.Date
+
+@Service
+class SurveyFinishScheduler(
+    private val surveyAdapter: SurveyAdapter,
+) {
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
+    @Scheduled(cron = "0 * * * * *") // 매 시 정각에 실행
+    fun closeExpiredSurveys() {
+        val targetSurveys = surveyAdapter.findFinishTargets(Date())
+        val finishedTargetSurveys =
+            targetSurveys.map {
+                log.info("설문 종료 시도: ${it.id}")
+                it.finish()
+            }
+
+        surveyAdapter.saveAll(finishedTargetSurveys)
+
+        log.info("${targetSurveys.size}개의 설문을 성공적으로 종료했습니다.")
+    }
+}


### PR DESCRIPTION
## 📢 설명 - 131번 브랜치 머지 후 리뷰 진행

- 1시간 마다 종료되어야 하는 설문들을 종료시키는 스케줄러 구현
    - 설문 종료 조건: (`IN_PROGRESS or IN_MODIFICATION`) and `finishedAt >= now` and `isDeleted == false`

## ✅ 체크 리스트

- [x]  `com.sbl.sulmun2yong.survey.scheduler.SurveyFinishScheduler.kt`의 `@Scheduled`의 내용을 아래와 같이 수정
    
    ```kotlin
    // ... 기존 코드들
        // 원래는 매 시 정각마다 실행인데 테스트를 위해 매 분 마다 실행하도록 수정
        @Scheduled(cron = "0 * * * * *")
        fun closeExpiredSurveys() {
    // ... 나머지 코드들
    ```
    
- [x]  설문 생성 후 아래 RequestBody로 설문 저장 API 호출 후 시작
    
    ```json
    {
        "title": "스케줄러 테스트 설문 1",
        "description": "",
        "thumbnail": null,
        "finishMessage": "설문에 참여해주셔서 감사합니다.",
        "isVisible": true,
        "rewardSetting": {
            "type": "SELF_MANAGEMENT",
            "rewards": [
                {
                    "category": "커피",
                    "name": "커피",
                    "count": 1,
                    "key": "8c44febc-ee40-44ea-92d8-c2ba096d6d3a"
                }
            ],
            "finishedAt": "2024-10-09T15:00:00.000Z",
            "targetParticipantCount": null
        },
        "sections": [
            {
                "sectionId": "5d264e25-9249-4eff-9a2f-d469a8984cbf",
                "title": "",
                "description": "",
                "routeDetails": {
                    "type": "NUMERICAL_ORDER",
                    "nextSectionId": null,
                    "keyQuestionId": null,
                    "sectionRouteConfigs": null
                },
                "questions": []
            }
        ]
    }
    ```
    
- [x]  한 번 더 설문 생성 후 아래 RequestBody로 설문 저장 API 호출 후 시작
    
    ```json
    {
        "title": "스케줄러 테스트 설문 2",
        "description": "",
        "thumbnail": null,
        "finishMessage": "설문에 참여해주셔서 감사합니다.",
        "isVisible": true,
        "rewardSetting": {
            "type": "SELF_MANAGEMENT",
            "rewards": [
                {
                    "category": "커피",
                    "name": "커피",
                    "count": 1,
                    "key": "8c44febc-ee40-44ea-92d8-c2ba096d6d3a"
                }
            ],
            "finishedAt": "2024-10-09T15:00:00.000Z",
            "targetParticipantCount": null
        },
        "sections": [
            {
                "sectionId": "5d264e25-9249-4eff-9a2f-d469a8984cbf",
                "title": "",
                "description": "",
                "routeDetails": {
                    "type": "NUMERICAL_ORDER",
                    "nextSectionId": null,
                    "keyQuestionId": null,
                    "sectionRouteConfigs": null
                },
                "questions": []
            }
        ]
    }
    ```
    
- [x]  방금 생성한 두 설문을 DB에서 `finishedAt`을 현재 시간의 정각으로 수정, `publishedAt`도 `finishedAt` 이전으로 수정
  - DB에는 UTC+0으로 저장되어 있으므로 `finishedAt`을 현재 한국 시간 - 9시간 & 분 단위 제거한 시간으로 수정
  - ex) 현재 한국 시간이 19:31 라면 10:00으로 수정
- [x]  m시 n분 0초가 되었을 때 스케줄러가 실행되며 로그가 정상적으로 출력되는지 확인(`2개의 설문을 성공적으로 종료했습니다.`)