### PR TITLE
[SBL-175] 파일 크기 검증 비즈니스 로직 제거

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/UserFileManagementConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/UserFileManagementConfig.kt
@@ -5,7 +5,6 @@ import com.sbl.sulmun2yong.global.util.validator.FileUrlValidator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.util.unit.DataSize
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
@@ -19,8 +18,6 @@ class UserFileManagementConfig(
     @Value("\${aws.s3.secret-key}")
     private val secretKey: String,
     // 파일 예외처리 관련
-    @Value("\${aws.s3.max-file-size}")
-    private val maxFileSize: DataSize,
     @Value("\${aws.s3.max-file-name-length}")
     private val maxFileNameLength: Int,
     @Value("\${aws.s3.allowed-extensions}")
@@ -44,7 +41,6 @@ class UserFileManagementConfig(
     @Bean
     fun createFileUploadValidator(): FileUploadValidator =
         FileUploadValidator.from(
-            maxFileSize = maxFileSize,
             maxFileNameLength = maxFileNameLength,
             allowedExtensions = allowedExtensions,
             allowedContentTypes = allowedContentTypes,

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -59,7 +59,6 @@ enum class ErrorCode(
 
     // File Validator (FV)
     INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "FV0001", "허용하지 않는 확장자입니다."),
-    OUT_OF_FILE_SIZE(HttpStatus.BAD_REQUEST, "FV0002", "파일 크기가 너무 큽니다."),
     FILE_NAME_TOO_SHORT(HttpStatus.BAD_REQUEST, "FV0003", "파일 이름이 너무 짧습니다."),
     FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "FV0004", "파일 이름이 너무 깁니다."),
     NO_FILE_EXIST(HttpStatus.BAD_REQUEST, "FV0005", "파일이 존재하지 않습니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/exception/OutOfFileSizeException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/exception/OutOfFileSizeException.kt
@@ -1,6 +1,0 @@
-package com.sbl.sulmun2yong.global.util.exception
-
-import com.sbl.sulmun2yong.global.error.BusinessException
-import com.sbl.sulmun2yong.global.error.ErrorCode
-
-class OutOfFileSizeException : BusinessException(ErrorCode.OUT_OF_FILE_SIZE)

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/validator/FileUploadValidator.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/validator/FileUploadValidator.kt
@@ -5,29 +5,23 @@ import com.sbl.sulmun2yong.global.util.exception.FileNameTooShortException
 import com.sbl.sulmun2yong.global.util.exception.InvalidExtensionException
 import com.sbl.sulmun2yong.global.util.exception.NoExtensionExistException
 import com.sbl.sulmun2yong.global.util.exception.NoFileExistException
-import com.sbl.sulmun2yong.global.util.exception.OutOfFileSizeException
-import org.springframework.util.unit.DataSize
 import org.springframework.web.multipart.MultipartFile
 
 class FileUploadValidator(
-    private val maxFileSize: Long,
     private val maxFileNameLength: Int,
     private val allowedExtensions: MutableList<String>,
     private val allowedContentTypes: MutableList<String>,
 ) {
     companion object {
         fun from(
-            maxFileSize: DataSize,
             maxFileNameLength: Int,
             allowedExtensions: String,
             allowedContentTypes: String,
         ): FileUploadValidator {
-            val fileSize = maxFileSize.toBytes()
             val extensions = allowedExtensions.split(",").toMutableList()
             val contentTypes = allowedContentTypes.split(",").toMutableList()
 
             return FileUploadValidator(
-                fileSize,
                 maxFileNameLength,
                 extensions,
                 contentTypes,
@@ -39,7 +33,6 @@ class FileUploadValidator(
         fun checkIsAllowedExtensionOrType(contentType: String): Boolean =
             allowedExtensions.contains(contentType) || allowedContentTypes.any { contentType.startsWith(it) }
 
-        val fileSize = file.size
         val fileName: String? = file.originalFilename
         val contentType = file.contentType
 
@@ -48,9 +41,6 @@ class FileUploadValidator(
         }
         if (contentType.isNullOrBlank()) {
             throw NoExtensionExistException()
-        }
-        if (fileSize > maxFileSize) {
-            throw OutOfFileSizeException()
         }
         if (fileName.isNullOrBlank()) {
             throw FileNameTooShortException()


### PR DESCRIPTION
## 📢 설명
413으로 클라이언트에 알아서 넘겨주므로 더 이상 비즈니스 에러를 throw하지 않음

## ✅ 체크 리스트
- [ ] 8MB 사진 다운로드 https://files.sulmoon.io/20241003_021347753_Imgae_8MB.jpg
- [ ] postman에 JSESSIONID 쿠키 설정
- [ ] application-secret.yml을 노션 것으로 변경
- [ ] 사진 업로드 요청해보고 스프링 콘솔에서 ```org.springframework.web.multipart.MaxUploadSizeExceededException: Maximum upload size exceeded```가 찍히는지 확인