### PR TITLE
[SBL-181] chatSessionId는 surveyId를 참조하도록 함

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/adapter/GenerateAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/adapter/GenerateAdapter.kt
@@ -11,12 +11,14 @@ import com.sbl.sulmun2yong.survey.domain.Survey
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestTemplate
+import java.util.UUID
 
 @Component
 class GenerateAdapter(
     private val requestToPythonServerTemplate: RestTemplate,
 ) {
     fun requestSurveyGenerationWithFileUrl(
+        chatSessionId: UUID,
         job: String,
         groupName: String,
         fileUrl: String,
@@ -26,6 +28,7 @@ class GenerateAdapter(
         val generateSurveyResponseFromPython =
             requestWithFileUrl(
                 GenerateWithFileUrlRequestToPython(
+                    chatSessionId = chatSessionId,
                     job = job,
                     groupName = groupName,
                     userPrompt = userPrompt,
@@ -37,6 +40,7 @@ class GenerateAdapter(
     }
 
     fun requestSurveyGenerationWithTextDocument(
+        chatSessionId: UUID,
         job: String,
         groupName: String,
         textDocument: String,
@@ -46,6 +50,7 @@ class GenerateAdapter(
         val generateSurveyResponseFromPython =
             requestWithTextDocument(
                 GenerateWithTextDocumentRequestToPython(
+                    chatSessionId = chatSessionId,
                     job = job,
                     groupName = groupName,
                     userPrompt = userPrompt,

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/controller/AIChatController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/controller/AIChatController.kt
@@ -22,13 +22,8 @@ class AIChatController(
         editSurveyDataWithChatRequest: EditSurveyDataWithChatRequest,
         request: HttpServletRequest,
         @LoginUser id: UUID,
-    ): ResponseEntity<AISurveyEditResponse> {
-        val cookies = request.cookies
-        val chatSessionId =
-            cookies?.firstOrNull { it.name == "chat-session-id" }?.value ?: UUID.randomUUID().toString()
-
-        return ResponseEntity.ok(
-            chatService.editSurveyDataWithChat(UUID.fromString(chatSessionId), makerId = id, editSurveyDataWithChatRequest),
+    ): ResponseEntity<AISurveyEditResponse> =
+        ResponseEntity.ok(
+            chatService.editSurveyDataWithChat(makerId = id, editSurveyDataWithChatRequest),
         )
-    }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/controller/AIChatController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/controller/AIChatController.kt
@@ -3,7 +3,6 @@ package com.sbl.sulmun2yong.ai.controller
 import com.sbl.sulmun2yong.ai.controller.doc.AIChatApiDoc
 import com.sbl.sulmun2yong.ai.dto.request.EditSurveyDataWithChatRequest
 import com.sbl.sulmun2yong.ai.dto.response.AISurveyEditResponse
-import com.sbl.sulmun2yong.ai.exception.ChatSessionIdCookieNotFoundException
 import com.sbl.sulmun2yong.ai.service.ChatService
 import com.sbl.sulmun2yong.global.annotation.LoginUser
 import jakarta.servlet.http.HttpServletRequest
@@ -26,7 +25,7 @@ class AIChatController(
     ): ResponseEntity<AISurveyEditResponse> {
         val cookies = request.cookies
         val chatSessionId =
-            cookies?.firstOrNull { it.name == "chat-session-id" }?.value ?: throw ChatSessionIdCookieNotFoundException()
+            cookies?.firstOrNull { it.name == "chat-session-id" }?.value ?: UUID.randomUUID().toString()
 
         return ResponseEntity.ok(
             chatService.editSurveyDataWithChat(UUID.fromString(chatSessionId), makerId = id, editSurveyDataWithChatRequest),

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/controller/AIGenerateController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/controller/AIGenerateController.kt
@@ -5,7 +5,6 @@ import com.sbl.sulmun2yong.ai.dto.request.SurveyGenerationWithFileUrlRequest
 import com.sbl.sulmun2yong.ai.dto.request.SurveyGenerationWithTextDocumentRequest
 import com.sbl.sulmun2yong.ai.service.GenerateService
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
-import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
@@ -27,7 +26,6 @@ class AIGenerateController(
         response: HttpServletResponse,
     ): ResponseEntity<SurveyMakeInfoResponse> {
         val aiSurveyGenerationResponse = generateService.generateSurveyWithFileUrl(surveyGenerationWithFileUrlRequest, surveyId)
-        setChatSessionIdCookie(response, aiSurveyGenerationResponse.chatSessionId)
         return ResponseEntity.ok(aiSurveyGenerationResponse.generatedSurvey)
     }
 
@@ -38,21 +36,6 @@ class AIGenerateController(
         response: HttpServletResponse,
     ): ResponseEntity<SurveyMakeInfoResponse> {
         val aiSurveyGenerationResponse = generateService.generateSurveyWithTextDocument(surveyGenerationWithTextDocumentRequest, surveyId)
-        setChatSessionIdCookie(response, aiSurveyGenerationResponse.chatSessionId)
         return ResponseEntity.ok(aiSurveyGenerationResponse.generatedSurvey)
-    }
-
-    private fun setChatSessionIdCookie(
-        response: HttpServletResponse,
-        chatSessionId: UUID,
-    ) {
-        val cookie =
-            Cookie("chat-session-id", chatSessionId.toString()).apply {
-                maxAge = 60 * 60 * 24
-                path = "/"
-                isHttpOnly = true
-            }
-
-        response.addCookie(cookie)
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/domain/AIGeneratedSurvey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/domain/AIGeneratedSurvey.kt
@@ -1,9 +1,7 @@
 package com.sbl.sulmun2yong.ai.domain
 
 import com.sbl.sulmun2yong.survey.domain.Survey
-import java.util.UUID
 
 class AIGeneratedSurvey(
-    val chatSessionId: UUID,
     val survey: Survey,
 )

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/request/GenerateRequestToPython.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/request/GenerateRequestToPython.kt
@@ -1,6 +1,9 @@
 package com.sbl.sulmun2yong.ai.dto.python.request
 
+import java.util.UUID
+
 interface GenerateRequestToPython {
+    val chatSessionId: UUID
     val job: String
     val groupName: String
     val userPrompt: String

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/request/GenerateWithFileUrlRequestToPython.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/request/GenerateWithFileUrlRequestToPython.kt
@@ -1,6 +1,9 @@
 package com.sbl.sulmun2yong.ai.dto.python.request
 
+import java.util.UUID
+
 data class GenerateWithFileUrlRequestToPython(
+    override val chatSessionId: UUID,
     override val job: String,
     override val groupName: String,
     override val userPrompt: String,

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/request/GenerateWithTextDocumentRequestToPython.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/request/GenerateWithTextDocumentRequestToPython.kt
@@ -1,6 +1,9 @@
 package com.sbl.sulmun2yong.ai.dto.python.request
 
+import java.util.UUID
+
 data class GenerateWithTextDocumentRequestToPython(
+    override val chatSessionId: UUID,
     override val job: String,
     override val groupName: String,
     override val userPrompt: String,

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/response/GenerateSurveyResponseFromPython.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/python/response/GenerateSurveyResponseFromPython.kt
@@ -2,15 +2,12 @@ package com.sbl.sulmun2yong.ai.dto.python.response
 
 import com.sbl.sulmun2yong.ai.domain.AIGeneratedSurvey
 import com.sbl.sulmun2yong.survey.domain.Survey
-import java.util.UUID
 
 data class GenerateSurveyResponseFromPython(
-    val chatSessionId: UUID,
     val survey: SurveyResponseFromPython,
 ) {
     fun toDomain(originalSurvey: Survey) =
         AIGeneratedSurvey(
-            chatSessionId = chatSessionId,
             survey = survey.toDomain().toNewSurvey(originalSurvey),
         )
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/request/SurveyGenerationWithFileUrlRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/request/SurveyGenerationWithFileUrlRequest.kt
@@ -1,7 +1,7 @@
 package com.sbl.sulmun2yong.ai.dto.request
 
 data class SurveyGenerationWithFileUrlRequest(
-    val job: String,
+    val target: String,
     val groupName: String,
     val fileUrl: String,
     val userPrompt: String,

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/request/SurveyGenerationWithTextDocumentRequest.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/request/SurveyGenerationWithTextDocumentRequest.kt
@@ -1,7 +1,7 @@
 package com.sbl.sulmun2yong.ai.dto.request
 
 data class SurveyGenerationWithTextDocumentRequest(
-    val job: String,
+    val target: String,
     val groupName: String,
     val textDocument: String,
     val userPrompt: String,

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/response/AISurveyGenerationResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/dto/response/AISurveyGenerationResponse.kt
@@ -2,14 +2,12 @@ package com.sbl.sulmun2yong.ai.dto.response
 
 import com.sbl.sulmun2yong.ai.domain.AIGeneratedSurvey
 import com.sbl.sulmun2yong.survey.dto.response.SurveyMakeInfoResponse
-import java.util.UUID
 
 data class AISurveyGenerationResponse(
-    val chatSessionId: UUID,
     val generatedSurvey: SurveyMakeInfoResponse,
 ) {
     companion object {
         fun from(aiGeneratedSurvey: AIGeneratedSurvey): AISurveyGenerationResponse =
-            AISurveyGenerationResponse(aiGeneratedSurvey.chatSessionId, SurveyMakeInfoResponse.of(aiGeneratedSurvey.survey))
+            AISurveyGenerationResponse(SurveyMakeInfoResponse.of(aiGeneratedSurvey.survey))
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/service/ChatService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/service/ChatService.kt
@@ -18,7 +18,6 @@ class ChatService(
     private val aiLogAdapter: AILogAdapter,
 ) {
     fun editSurveyDataWithChat(
-        chatSessionId: UUID,
         makerId: UUID,
         editSurveyDataWithChatRequest: EditSurveyDataWithChatRequest,
     ): AISurveyEditResponse {
@@ -36,7 +35,7 @@ class ChatService(
         val updatedSurvey =
             targetSurvey.editSurveyWithAI(
                 modificationTargetId = modificationTargetId,
-                chatSessionId = chatSessionId,
+                chatSessionId = surveyId,
                 userPrompt = userPrompt,
             )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/service/GenerateService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/service/GenerateService.kt
@@ -21,7 +21,7 @@ class GenerateService(
     ): AISurveyGenerationResponse {
         val allowedExtensions = mutableListOf(".txt", ".pdf")
 
-        val job = surveyGenerationWithFileUrlRequest.job
+        val job = surveyGenerationWithFileUrlRequest.target
         val groupName = surveyGenerationWithFileUrlRequest.groupName
         val fileUrl = surveyGenerationWithFileUrlRequest.fileUrl
         val userPrompt = surveyGenerationWithFileUrlRequest.userPrompt
@@ -39,7 +39,7 @@ class GenerateService(
         surveyGenerationWithTextDocumentRequest: SurveyGenerationWithTextDocumentRequest,
         surveyId: UUID,
     ): AISurveyGenerationResponse {
-        val job = surveyGenerationWithTextDocumentRequest.job
+        val job = surveyGenerationWithTextDocumentRequest.target
         val groupName = surveyGenerationWithTextDocumentRequest.groupName
         val textDocument = surveyGenerationWithTextDocumentRequest.textDocument
         val userPrompt = surveyGenerationWithTextDocumentRequest.userPrompt

--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/service/GenerateService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/service/GenerateService.kt
@@ -31,7 +31,7 @@ class GenerateService(
         val survey = surveyAdapter.getSurvey(surveyId)
 
         return AISurveyGenerationResponse.from(
-            generateAdapter.requestSurveyGenerationWithFileUrl(job, groupName, fileUrl, userPrompt, survey),
+            generateAdapter.requestSurveyGenerationWithFileUrl(surveyId, job, groupName, fileUrl, userPrompt, survey),
         )
     }
 
@@ -47,7 +47,7 @@ class GenerateService(
         val survey = surveyAdapter.getSurvey(surveyId)
 
         return AISurveyGenerationResponse.from(
-            generateAdapter.requestSurveyGenerationWithTextDocument(job, groupName, textDocument, userPrompt, survey),
+            generateAdapter.requestSurveyGenerationWithTextDocument(surveyId, job, groupName, textDocument, userPrompt, survey),
         )
     }
 }


### PR DESCRIPTION
## 📢 설명 - https://github.com/SUIN-BUNDANG-LINE/AI/pull/15 와 연계하여 테스트
- 파이썬 서버에 chat_session_id를 포함하여 요청을 보냄
- 더이상 chat_session_id쿠키를 만들지 않음
- surveyId를 chat session id로 삼고 파이썬 서버에 요청을 보냄

## ✅ 체크 리스트
- [x] https://github.com/SUIN-BUNDANG-LINE/AI/pull/15 와 연계하여 테스트
- [x] 설문 생성 API 호출로 surveyId 획득
- [x] 그 surveyId로 초안 생성 API 호출
- [x] redis에 ```message_store:{surveyId}``` 형태로 문서 요약 저장이 되었는지 확인
- [x] 초안 생성 API호출된 결과를 저장하지 않고 수정을 요청해봤을때, 즉 빈설문 상태일때 제공한 문서 관련 내용으로 만들어지는지 확인
- [x] 초안 생성으로 만들지 않은 설문의 surveyId로 수정을 요청해봤을때 수정이 되는지 확인
