### PR TITLE
[SBL-204] 성능 테스트를 위해 필요한 더미데이터를 생성하기 위한 API 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResponseController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyResponseController.kt
@@ -1,6 +1,5 @@
 package com.sbl.sulmun2yong.survey.controller
 
-import com.sbl.sulmun2yong.global.annotation.IsAdmin
 import com.sbl.sulmun2yong.survey.controller.doc.SurveyResponseApiDoc
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
 import com.sbl.sulmun2yong.survey.service.SurveyResponseService
@@ -22,6 +21,5 @@ class SurveyResponseController(
     override fun responseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,
         @Valid @RequestBody surveyResponseRequest: SurveyResponseRequest,
-        @IsAdmin isAdmin: Boolean,
-    ) = ResponseEntity.ok(surveyResponseService.responseToSurvey(surveyId, surveyResponseRequest, isAdmin))
+    ) = ResponseEntity.ok(surveyResponseService.responseToSurvey(surveyId, surveyResponseRequest))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResponseApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyResponseApiDoc.kt
@@ -1,6 +1,5 @@
 package com.sbl.sulmun2yong.survey.controller.doc
 
-import com.sbl.sulmun2yong.global.annotation.IsAdmin
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
 import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -19,6 +18,5 @@ interface SurveyResponseApiDoc {
     fun responseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,
         @Valid @RequestBody surveyResponseRequest: SurveyResponseRequest,
-        @IsAdmin isAdmin: Boolean,
     ): ResponseEntity<SurveyParticipantResponse>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResponseService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyResponseService.kt
@@ -22,18 +22,10 @@ class SurveyResponseService(
     fun responseToSurvey(
         surveyId: UUID,
         surveyResponseRequest: SurveyResponseRequest,
-        isAdmin: Boolean,
     ): SurveyParticipantResponse {
-        val visitorId =
-            if (!isAdmin) {
-                // Admin이 아닌 경우 visitorId의 유효성을 검증
-                validateIsAlreadyParticipated(surveyId, surveyResponseRequest.visitorId)
-                fingerprintApi.validateVisitorId(surveyResponseRequest.visitorId)
-                surveyResponseRequest.visitorId
-            } else {
-                // Admin인 경우 visitorId를 랜덤으로 생성
-                UUID.randomUUID().toString()
-            }
+        validateIsAlreadyParticipated(surveyId, surveyResponseRequest.visitorId)
+        fingerprintApi.validateVisitorId(surveyResponseRequest.visitorId)
+        val visitorId = surveyResponseRequest.visitorId
         val survey = surveyAdapter.getSurvey(surveyId)
         val surveyResponse = surveyResponseRequest.toDomain(surveyId)
         survey.validateResponse(surveyResponse)

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/AdminController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/AdminController.kt
@@ -4,6 +4,7 @@ import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupListResponse
 import com.sbl.sulmun2yong.drawing.dto.response.DrawingHistoryGroupResponse
 import com.sbl.sulmun2yong.user.controller.doc.AdminApiDoc
 import com.sbl.sulmun2yong.user.service.AdminService
+import com.sbl.sulmun2yong.user.service.DummyDataService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,6 +18,7 @@ import java.util.UUID
 @RequestMapping("/api/v1/admin")
 class AdminController(
     private val adminService: AdminService,
+    private val dummyDataService: DummyDataService,
 ) : AdminApiDoc {
     @GetMapping("/drawing-history/{surveyId}")
     override fun getDrawingHistory(
@@ -29,4 +31,9 @@ class AdminController(
     override fun getDrawingHistoryList(
         @RequestParam(defaultValue = "false") isWinnerOnly: Boolean,
     ): ResponseEntity<DrawingHistoryGroupListResponse> = ResponseEntity.ok(adminService.getDrawingHistoryList(isWinnerOnly))
+
+    @GetMapping("/dummy-data")
+    override fun insertDummyData(
+        @RequestParam surveyCount: Int,
+    ) = ResponseEntity.ok(dummyDataService.insertDummyData(surveyCount))
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/AdminApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/controller/doc/AdminApiDoc.kt
@@ -24,4 +24,10 @@ interface AdminApiDoc {
     fun getDrawingHistoryList(
         @RequestParam(defaultValue = "false") isWinnerOnly: Boolean,
     ): ResponseEntity<DrawingHistoryGroupListResponse>
+
+    @Operation(summary = "더미 데이터 생성")
+    @GetMapping("/dummy-data")
+    fun insertDummyData(
+        @RequestParam surveyCount: Int,
+    ): ResponseEntity<Unit>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/domain/User.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/domain/User.kt
@@ -2,8 +2,8 @@ package com.sbl.sulmun2yong.user.domain
 
 import com.sbl.sulmun2yong.global.config.oauth2.provider.Provider
 import com.sbl.sulmun2yong.global.data.PhoneNumber
-import com.sbl.sulmun2yong.global.util.RandomNicknameGenerator
 import com.sbl.sulmun2yong.user.exception.InvalidUserException
+import com.sbl.sulmun2yong.user.util.RandomNicknameGenerator
 import java.util.UUID
 
 data class User(

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/service/DummyDataService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/service/DummyDataService.kt
@@ -1,0 +1,46 @@
+package com.sbl.sulmun2yong.user.service
+
+import com.sbl.sulmun2yong.survey.domain.Survey
+import com.sbl.sulmun2yong.survey.entity.ParticipantDocument
+import com.sbl.sulmun2yong.survey.entity.ResponseDocument
+import com.sbl.sulmun2yong.survey.entity.SurveyDocument
+import com.sbl.sulmun2yong.user.entity.UserDocument
+import com.sbl.sulmun2yong.user.util.Probability
+import com.sbl.sulmun2yong.user.util.RandomParticipantGenerateUtil.generateRandomParticipants
+import com.sbl.sulmun2yong.user.util.RandomResponseGenerateUtil.generateSurveyResponseDocuments
+import com.sbl.sulmun2yong.user.util.RandomSurveyGenerateUtil.generateRandomSurvey
+import com.sbl.sulmun2yong.user.util.RandomUserGenerateUtil.generateRandomUser
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.stereotype.Service
+import kotlin.math.max
+
+@Service
+class DummyDataService(
+    private val mongoTemplate: MongoTemplate,
+) {
+    companion object {
+        private val randomIsDeleted = Probability(0.1)
+    }
+
+    fun insertDummyData(surveyCount: Int) {
+        val userCount = max(1, surveyCount / 10)
+        val users = (1..userCount).map { generateRandomUser() }
+        val surveys = (1..surveyCount).map { generateRandomSurvey(users.random().id) }
+
+        mongoTemplate.insert(users.map { UserDocument.of(it) }, UserDocument::class.java)
+        mongoTemplate.insert(surveys.map { getRandomSurveyDocument(it) }, SurveyDocument::class.java)
+
+        for (survey in surveys) {
+            val participants = generateRandomParticipants(survey.id)
+            val responseDocuments: List<ResponseDocument> = generateSurveyResponseDocuments(survey, participants)
+            mongoTemplate.insert(participants.map { ParticipantDocument.of(it) }, ParticipantDocument::class.java)
+            mongoTemplate.insert(responseDocuments, ResponseDocument::class.java)
+        }
+    }
+
+    private fun getRandomSurveyDocument(survey: Survey): SurveyDocument {
+        val surveyDocument = SurveyDocument.from(survey)
+        if (randomIsDeleted.isWinning()) return surveyDocument.copy(isDeleted = true)
+        return surveyDocument
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/Probability.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/Probability.kt
@@ -1,0 +1,11 @@
+package com.sbl.sulmun2yong.user.util
+
+data class Probability(
+    private val chance: Double,
+) {
+    init {
+        require(chance in 0.0..1.0) { "확률은 0과 1 사이의 값이어야 합니다." }
+    }
+
+    fun isWinning(): Boolean = Math.random() <= chance
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/ProbabilityPicker.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/ProbabilityPicker.kt
@@ -1,0 +1,25 @@
+package com.sbl.sulmun2yong.user.util
+
+import kotlin.math.abs
+
+data class ProbabilityPicker<T>(
+    private val probabilityMap: Map<T, Double>,
+) {
+    init {
+        val totalProbability = probabilityMap.values.sum()
+        // 부동소수점 오차를 고려하여 1에 가까운지 확인
+        require(abs(totalProbability - 1.0) < 1e-9) { "확률의 합은 1이어야 합니다." }
+    }
+
+    fun pick(): T {
+        val randomValue = Math.random()
+        var totalProbability = 0.0
+
+        for ((item, probability) in probabilityMap) {
+            totalProbability += probability
+            if (randomValue <= totalProbability) return item
+        }
+
+        return probabilityMap.keys.last()
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomNicknameGenerator.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomNicknameGenerator.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.global.util
+package com.sbl.sulmun2yong.user.util
 
 import kotlin.random.Random
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomParticipantGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomParticipantGenerateUtil.kt
@@ -4,23 +4,23 @@ import com.sbl.sulmun2yong.survey.domain.Participant
 import java.util.UUID
 
 object RandomParticipantGenerateUtil {
-    // 한 설문 당 평균 111명 참여
+    // 한 설문 당 평균 113명 참여
     private val randomParticipantCountPicker =
         ProbabilityPicker(
             mapOf(
-                0 to 0.05,
-                1 to 0.05,
-                3 to 0.1,
-                5 to 0.3,
-                10 to 0.35,
-                20 to 0.1,
-                50 to 0.025,
-                100 to 0.025,
+                0 to 0.075,
+                10 to 0.1,
+                30 to 0.2,
+                50 to 0.2,
+                100 to 0.25,
+                200 to 0.1,
+                500 to 0.05,
+                1000 to 0.025,
             ),
         )
 
     fun generateRandomParticipants(surveyId: UUID) =
-        (1..randomParticipantCountPicker.pick() * 10).map {
+        (1..randomParticipantCountPicker.pick()).map {
             generateRandomParticipant(surveyId)
         }
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomParticipantGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomParticipantGenerateUtil.kt
@@ -1,0 +1,33 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.survey.domain.Participant
+import java.util.UUID
+
+object RandomParticipantGenerateUtil {
+    // 한 설문 당 평균 111명 참여
+    private val randomParticipantCountPicker =
+        ProbabilityPicker(
+            mapOf(
+                0 to 0.05,
+                1 to 0.05,
+                3 to 0.1,
+                5 to 0.3,
+                10 to 0.35,
+                20 to 0.1,
+                50 to 0.025,
+                100 to 0.025,
+            ),
+        )
+
+    fun generateRandomParticipants(surveyId: UUID) =
+        (1..randomParticipantCountPicker.pick() * 10).map {
+            generateRandomParticipant(surveyId)
+        }
+
+    private fun generateRandomParticipant(surveyId: UUID) =
+        Participant.create(
+            visitorId = UUID.randomUUID().toString(),
+            surveyId = surveyId,
+            userId = null,
+        )
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomQuestionGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomQuestionGenerateUtil.kt
@@ -1,0 +1,80 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.survey.domain.question.Question
+import com.sbl.sulmun2yong.survey.domain.question.QuestionType
+import com.sbl.sulmun2yong.survey.domain.question.choice.Choice
+import com.sbl.sulmun2yong.survey.domain.question.choice.Choices
+import com.sbl.sulmun2yong.survey.domain.question.impl.StandardMultipleChoiceQuestion
+import com.sbl.sulmun2yong.survey.domain.question.impl.StandardSingleChoiceQuestion
+import com.sbl.sulmun2yong.survey.domain.question.impl.StandardTextQuestion
+import java.util.UUID
+
+object RandomQuestionGenerateUtil {
+    private val randomQuestionTypePicker =
+        ProbabilityPicker(
+            mapOf(
+                QuestionType.SINGLE_CHOICE to 0.6,
+                QuestionType.MULTIPLE_CHOICE to 0.3,
+                QuestionType.TEXT_RESPONSE to 0.1,
+            ),
+        )
+
+    private val randomIsRequired = Probability(0.7)
+    private val randomIsAllowOther = Probability(0.2)
+
+    private val randomChoiceCountPicker =
+        ProbabilityPicker(
+            mapOf(
+                2 to 0.2,
+                3 to 0.15,
+                4 to 0.15,
+                5 to 0.15,
+                6 to 0.15,
+                7 to 0.1,
+                8 to 0.1,
+            ),
+        )
+
+    fun generateRandomQuestion(index: Int): Question {
+        val id = UUID.randomUUID()
+        val title = "${index + 1}번 질문"
+        val description = "${index + 1}번 질문 설명"
+        val isRequired = randomIsRequired.isWinning()
+        val questionType = randomQuestionTypePicker.pick()
+
+        return when (questionType) {
+            QuestionType.SINGLE_CHOICE ->
+                StandardSingleChoiceQuestion(
+                    id = id,
+                    title = title,
+                    description = description,
+                    isRequired = isRequired,
+                    choices = generateRandomChoices(),
+                )
+            QuestionType.MULTIPLE_CHOICE ->
+                StandardMultipleChoiceQuestion(
+                    id = id,
+                    title = title,
+                    description = description,
+                    isRequired = isRequired,
+                    choices = generateRandomChoices(),
+                )
+            QuestionType.TEXT_RESPONSE ->
+                StandardTextQuestion(
+                    id = id,
+                    title = title,
+                    description = description,
+                    isRequired = isRequired,
+                )
+        }
+    }
+
+    private fun generateRandomChoices(): Choices {
+        val choiceCount = randomChoiceCountPicker.pick()
+        val choices = (0 until choiceCount).map { "선택지 ${it + 1}" }
+        return Choices(
+            standardChoices = choices.map { Choice.Standard(it) },
+            isAllowOther = randomIsAllowOther.isWinning(),
+        )
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomResponseGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomResponseGenerateUtil.kt
@@ -1,0 +1,42 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.survey.domain.Participant
+import com.sbl.sulmun2yong.survey.domain.Survey
+import com.sbl.sulmun2yong.survey.domain.question.ChoiceQuestion
+import com.sbl.sulmun2yong.survey.entity.ResponseDocument
+import java.util.UUID
+
+object RandomResponseGenerateUtil {
+    private val isResponded = Probability(0.6)
+
+    /** 각 참가자별로 설문의 응답을 랜덤하게 생성하여 반환하는 메서드. */
+    fun generateSurveyResponseDocuments(
+        survey: Survey,
+        participants: List<Participant>,
+    ): List<ResponseDocument> {
+        val questions = survey.sections.flatMap { it.questions }
+        return questions.flatMap { question ->
+            participants.mapNotNull { participant ->
+                if (question.isRequired || isResponded.isWinning()) {
+                    ResponseDocument(
+                        id = UUID.randomUUID(),
+                        participantId = participant.id,
+                        surveyId = survey.id,
+                        questionId = question.id,
+                        content =
+                            if (question is ChoiceQuestion) {
+                                question.choices
+                                    .getChoiceSet()
+                                    .random()
+                                    .content ?: "잘 모르겠어요"
+                            } else {
+                                "${question.title}에 대한 ${participant.visitorId}의 주관식 답변"
+                            },
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomSectionGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomSectionGenerateUtil.kt
@@ -1,0 +1,43 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.survey.domain.routing.RoutingStrategy
+import com.sbl.sulmun2yong.survey.domain.section.Section
+import com.sbl.sulmun2yong.survey.domain.section.SectionId
+import com.sbl.sulmun2yong.survey.domain.section.SectionIds
+import com.sbl.sulmun2yong.user.util.RandomQuestionGenerateUtil.generateRandomQuestion
+
+object RandomSectionGenerateUtil {
+    private val randomQuestionCountPicker =
+        ProbabilityPicker(
+            mapOf(
+                1 to 0.1,
+                2 to 0.1,
+                3 to 0.15,
+                4 to 0.15,
+                5 to 0.15,
+                6 to 0.15,
+                7 to 0.1,
+                8 to 0.1,
+            ),
+        )
+
+    fun generateRandomSection(
+        index: Int,
+        id: SectionId.Standard,
+        sectionIds: SectionIds,
+    ): Section {
+        val title = "${index + 1}번 섹션"
+        val description = "${index + 1}번 섹션 설명"
+        val questionCount = randomQuestionCountPicker.pick()
+
+        return Section(
+            id = id,
+            title = title,
+            description = description,
+            // 편의상 NumericalOrder로 고정
+            routingStrategy = RoutingStrategy.NumericalOrder,
+            questions = (0 until questionCount).map { generateRandomQuestion(it) },
+            sectionIds = sectionIds,
+        )
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomSurveyGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomSurveyGenerateUtil.kt
@@ -27,11 +27,10 @@ object RandomSurveyGenerateUtil {
         ProbabilityPicker(
             mapOf(
                 1 to 0.15,
-                2 to 0.2,
-                3 to 0.2,
+                2 to 0.25,
+                3 to 0.35,
                 4 to 0.2,
-                5 to 0.15,
-                6 to 0.1,
+                5 to 0.05,
             ),
         )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomSurveyGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomSurveyGenerateUtil.kt
@@ -1,0 +1,119 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.survey.domain.Survey
+import com.sbl.sulmun2yong.survey.domain.SurveyStatus
+import com.sbl.sulmun2yong.survey.domain.reward.FinishedAt
+import com.sbl.sulmun2yong.survey.domain.reward.NoRewardSetting
+import com.sbl.sulmun2yong.survey.domain.reward.Reward
+import com.sbl.sulmun2yong.survey.domain.reward.RewardSettingType
+import com.sbl.sulmun2yong.survey.domain.reward.SelfManagementSetting
+import com.sbl.sulmun2yong.survey.domain.section.Section
+import com.sbl.sulmun2yong.survey.domain.section.SectionId
+import com.sbl.sulmun2yong.survey.domain.section.SectionIds
+import java.util.UUID
+
+object RandomSurveyGenerateUtil {
+    private val randomSurveyStatusPicker =
+        ProbabilityPicker(
+            mapOf(
+                SurveyStatus.NOT_STARTED to 0.1,
+                SurveyStatus.IN_PROGRESS to 0.45,
+                SurveyStatus.IN_MODIFICATION to 0.05,
+                SurveyStatus.CLOSED to 0.4,
+            ),
+        )
+
+    private val randomSectionCountPicker =
+        ProbabilityPicker(
+            mapOf(
+                1 to 0.15,
+                2 to 0.2,
+                3 to 0.2,
+                4 to 0.2,
+                5 to 0.15,
+                6 to 0.1,
+            ),
+        )
+
+    private val randomRewardSettingTypePicker =
+        ProbabilityPicker(
+            mapOf(
+                RewardSettingType.NO_REWARD to 0.5,
+                RewardSettingType.SELF_MANAGEMENT to 0.5,
+                // 편의상 즉시 추첨은 제외
+            ),
+        )
+
+    private val randomIsVisible = Probability(0.7)
+    private val randomIsResultOpen = Probability(0.5)
+
+    private val randomRewardPicker =
+        ProbabilityPicker(
+            mapOf(
+                Reward("스타벅스 아메리카노 T", "커피", 10) to 0.25,
+                Reward("스타벅스 카페라떼 T", "커피", 10) to 0.25,
+                Reward("BBQ 황금올리브", "치킨", 10) to 0.25,
+                Reward("BHC 맛초킹", "치킨", 10) to 0.25,
+            ),
+        )
+
+    fun generateRandomSurvey(makerId: UUID): Survey {
+        val id = UUID.randomUUID()
+        val title = "설문 $id"
+        val description = "설문 $id 설명"
+        val surveyStatus = randomSurveyStatusPicker.pick()
+        val finishMessage = "설문 $id 종료 메시지"
+        val isVisible = randomIsVisible.isWinning()
+        val isResultOpen = randomIsResultOpen.isWinning()
+        val sections = getRandomSections()
+        val publishedAt =
+            when (surveyStatus) {
+                SurveyStatus.NOT_STARTED -> null
+                else -> RandomUtil.getRandomDate(-40, -30)
+            }
+        val rewardSetting =
+            when (randomRewardSettingTypePicker.pick()) {
+                RewardSettingType.NO_REWARD -> NoRewardSetting
+                RewardSettingType.SELF_MANAGEMENT ->
+                    SelfManagementSetting(
+                        rewards =
+                            listOf(
+                                randomRewardPicker.pick(),
+                            ),
+                        finishedAt =
+                            when (surveyStatus) {
+                                SurveyStatus.NOT_STARTED -> FinishedAt(RandomUtil.getRandomDate(30, 40))
+                                SurveyStatus.CLOSED -> FinishedAt(RandomUtil.getRandomDate(-20, -10))
+                                else -> FinishedAt(RandomUtil.getRandomDate(10, 20))
+                            },
+                    )
+
+                else -> throw IllegalArgumentException("즉시 추첨 방식은 지원되지 않습니다.")
+            }
+
+        return Survey(
+            id = id,
+            title = title,
+            description = description,
+            // 편의상 null로 고정
+            thumbnail = null,
+            publishedAt = publishedAt,
+            status = surveyStatus,
+            finishMessage = finishMessage,
+            rewardSetting = rewardSetting,
+            isVisible = isVisible,
+            makerId = makerId,
+            isResultOpen = isResultOpen,
+            sections = sections,
+        )
+    }
+
+    private fun getRandomSections(): List<Section> {
+        val sectionCount = randomSectionCountPicker.pick()
+        val sectionIdList = (0 until sectionCount).map { SectionId.Standard(UUID.randomUUID()) }
+        val sectionIds = SectionIds.from(sectionIdList)
+        return sectionIdList.mapIndexed { index, sectionId ->
+            RandomSectionGenerateUtil.generateRandomSection(index, sectionId, sectionIds)
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomUserGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomUserGenerateUtil.kt
@@ -1,0 +1,19 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.global.config.oauth2.provider.Provider
+import com.sbl.sulmun2yong.global.util.RandomNicknameGenerator
+import com.sbl.sulmun2yong.user.domain.User
+import com.sbl.sulmun2yong.user.domain.UserRole
+import java.util.UUID
+
+object RandomUserGenerateUtil {
+    fun generateRandomUser() =
+        User(
+            id = UUID.randomUUID(),
+            provider = listOf(Provider.GOOGLE, Provider.KAKAO).random(),
+            providerId = UUID.randomUUID().toString(),
+            nickname = RandomNicknameGenerator.generate(),
+            phoneNumber = null,
+            role = UserRole.ROLE_USER,
+        )
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomUserGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomUserGenerateUtil.kt
@@ -1,7 +1,6 @@
 package com.sbl.sulmun2yong.user.util
 
 import com.sbl.sulmun2yong.global.config.oauth2.provider.Provider
-import com.sbl.sulmun2yong.global.util.RandomNicknameGenerator
 import com.sbl.sulmun2yong.user.domain.User
 import com.sbl.sulmun2yong.user.domain.UserRole
 import java.util.UUID

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomUtil.kt
@@ -1,0 +1,13 @@
+package com.sbl.sulmun2yong.user.util
+
+import com.sbl.sulmun2yong.global.util.DateUtil
+import java.util.Date
+
+object RandomUtil {
+    /** 현재 날짜 기준 min일과 max일 사이의 무작위 날짜를 반환 */
+    fun getRandomDate(
+        min: Int,
+        max: Int,
+        noMin: Boolean = true,
+    ): Date = DateUtil.getDateAfterDay(date = DateUtil.getCurrentDate(noMin = noMin), day = (min..max).random())
+}


### PR DESCRIPTION
## 📢 설명
- 성능 테스트를 위해 필요한 더미데이터를 생성하기 위한 API 구현
- [GET] /api/v1/admin/dummy-data?surveyCount=100

## ✅ 체크 리스트
- [x] admin 계정으로 로그인 후 더미데이터 생성 API를 호출하여 surveyCount 값 만큼의 설문이 생성되는지 확인
- [x] 추가적으로, 유저, 참여자, 응답들도 DB에 잘 생성되었는지 확인
- [x] (선택) 프론트엔드와 연계하여 생성된 더미 설문들이 잘 동작하는지 확인
