### PR TITLE
[SBL-207] 테스트를 위한 Fingerprint Mocking Server를 사용하는 설문 응답 API 구현

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -80,6 +80,7 @@ jobs:
             FRONTEND_BASE_URL: http://localhost:3000
             BACKEND_BASE_URL: https://dev-api.sulmoon.io
             AI_SERVER_BASE_URL: http://ai.sulmoon.io:8000
+            FINGERPRINT_MOCKING_SERVER_URL: ${{ secrets.FINGERPRINT_MOCKING_SERVER_URL }}
             # New Relic 관련
             NEW_RELIC_APP_NAME: sulmun2yong-development
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/util/FakeFingerprintApi.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/util/FakeFingerprintApi.kt
@@ -1,0 +1,30 @@
+package com.sbl.sulmun2yong.global.util
+
+import jakarta.ws.rs.client.Client
+import jakarta.ws.rs.client.ClientBuilder
+import jakarta.ws.rs.client.Invocation
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.Response
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@ConditionalOnProperty(prefix = "fingerprint", name = ["mocking-server-url"], matchIfMissing = false)
+@Component
+class FakeFingerprintApi(
+    @Value("\${fingerprint.mocking-server-url}")
+    private val mockingServerUrl: String,
+) {
+    private val url = "$mockingServerUrl/finger-print"
+    private val client: Client = ClientBuilder.newClient()
+
+    fun callFingerPrintApi(visitorId: String) {
+        val target = client.target(url)
+        val invocationBuilder: Invocation.Builder = target.request(MediaType.APPLICATION_JSON_TYPE)
+        val response: Response = invocationBuilder.get()
+
+        if (response.status != Response.Status.OK.statusCode) {
+            throw IllegalStateException("Fake 핑거프린트 API를 호출할 수 없습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/FakeSurveyResponseController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/FakeSurveyResponseController.kt
@@ -1,0 +1,27 @@
+package com.sbl.sulmun2yong.survey.controller
+
+import com.sbl.sulmun2yong.survey.controller.doc.FakeSurveyResponseApiDoc
+import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
+import com.sbl.sulmun2yong.survey.service.FakeSurveyResponseService
+import jakarta.validation.Valid
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@ConditionalOnProperty(prefix = "fingerprint", name = ["mocking-server-url"], matchIfMissing = false)
+@RestController
+@RequestMapping("/api/v1/surveys/response/fake")
+class FakeSurveyResponseController(
+    private val fakeSurveyResponseService: FakeSurveyResponseService,
+) : FakeSurveyResponseApiDoc {
+    @PostMapping("/{survey-id}")
+    override fun fakeResponseToSurvey(
+        @PathVariable("survey-id") surveyId: UUID,
+        @Valid @RequestBody surveyResponseRequest: SurveyResponseRequest,
+    ) = ResponseEntity.ok(fakeSurveyResponseService.fakeResponseToSurvey(surveyId, surveyResponseRequest))
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/FakeSurveyResponseApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/FakeSurveyResponseApiDoc.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 @Tag(name = "FakeSurveyResponse", description = "테스트용 설문 응답 관련 API")
 interface FakeSurveyResponseApiDoc {
-    @Operation(summary = "설문 응답")
+    @Operation(summary = "Fingerprint Mocking 서버를 사용하는 설문 응답 API")
     @PostMapping
     fun fakeResponseToSurvey(
         @PathVariable("survey-id") surveyId: UUID,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/FakeSurveyResponseApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/FakeSurveyResponseApiDoc.kt
@@ -1,0 +1,22 @@
+package com.sbl.sulmun2yong.survey.controller.doc
+
+import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
+import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import java.util.UUID
+
+@Tag(name = "FakeSurveyResponse", description = "테스트용 설문 응답 관련 API")
+interface FakeSurveyResponseApiDoc {
+    @Operation(summary = "설문 응답")
+    @PostMapping
+    fun fakeResponseToSurvey(
+        @PathVariable("survey-id") surveyId: UUID,
+        @Valid @RequestBody surveyResponseRequest: SurveyResponseRequest,
+    ): ResponseEntity<SurveyParticipantResponse>
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/FakeSurveyResponseService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/FakeSurveyResponseService.kt
@@ -1,0 +1,49 @@
+package com.sbl.sulmun2yong.survey.service
+
+import com.sbl.sulmun2yong.global.util.FakeFingerprintApi
+import com.sbl.sulmun2yong.survey.adapter.ParticipantAdapter
+import com.sbl.sulmun2yong.survey.adapter.ResponseAdapter
+import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
+import com.sbl.sulmun2yong.survey.domain.Participant
+import com.sbl.sulmun2yong.survey.dto.request.SurveyResponseRequest
+import com.sbl.sulmun2yong.survey.dto.response.SurveyParticipantResponse
+import com.sbl.sulmun2yong.survey.exception.AlreadyParticipatedException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@ConditionalOnProperty(prefix = "fingerprint", name = ["mocking-server-url"], matchIfMissing = false)
+@Service
+class FakeSurveyResponseService(
+    val surveyAdapter: SurveyAdapter,
+    val participantAdapter: ParticipantAdapter,
+    val responseAdapter: ResponseAdapter,
+    val fakeFingerprintApi: FakeFingerprintApi,
+) {
+    fun fakeResponseToSurvey(
+        surveyId: UUID,
+        surveyResponseRequest: SurveyResponseRequest,
+    ): SurveyParticipantResponse {
+        validateIsAlreadyParticipated(surveyId, surveyResponseRequest.visitorId)
+        // 가짜 Fingerprint API를 호출하는 부분을 제외하고는 SurveyResponseService responseToSurvey 동일
+        fakeFingerprintApi.callFingerPrintApi(surveyResponseRequest.visitorId)
+        val visitorId = surveyResponseRequest.visitorId
+        val survey = surveyAdapter.getSurvey(surveyId)
+        val surveyResponse = surveyResponseRequest.toDomain(surveyId)
+        survey.validateResponse(surveyResponse)
+        val participant = Participant.create(visitorId, surveyId, null)
+        participantAdapter.insert(participant)
+        responseAdapter.insertSurveyResponse(surveyResponse, participant.id)
+        return SurveyParticipantResponse(participant.id, survey.isImmediateDraw())
+    }
+
+    private fun validateIsAlreadyParticipated(
+        surveyId: UUID,
+        visitorId: String,
+    ) {
+        val participant = participantAdapter.findBySurveyIdAndVisitorId(surveyId, visitorId)
+        participant?.let {
+            throw AlreadyParticipatedException()
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/service/DummyDataService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/service/DummyDataService.kt
@@ -5,11 +5,11 @@ import com.sbl.sulmun2yong.survey.entity.ParticipantDocument
 import com.sbl.sulmun2yong.survey.entity.ResponseDocument
 import com.sbl.sulmun2yong.survey.entity.SurveyDocument
 import com.sbl.sulmun2yong.user.entity.UserDocument
-import com.sbl.sulmun2yong.user.util.Probability
-import com.sbl.sulmun2yong.user.util.RandomParticipantGenerateUtil.generateRandomParticipants
-import com.sbl.sulmun2yong.user.util.RandomResponseGenerateUtil.generateSurveyResponseDocuments
-import com.sbl.sulmun2yong.user.util.RandomSurveyGenerateUtil.generateRandomSurvey
-import com.sbl.sulmun2yong.user.util.RandomUserGenerateUtil.generateRandomUser
+import com.sbl.sulmun2yong.user.util.dummy.Probability
+import com.sbl.sulmun2yong.user.util.dummy.RandomParticipantGenerateUtil.generateRandomParticipants
+import com.sbl.sulmun2yong.user.util.dummy.RandomResponseGenerateUtil.generateSurveyResponseDocuments
+import com.sbl.sulmun2yong.user.util.dummy.RandomSurveyGenerateUtil.generateRandomSurvey
+import com.sbl.sulmun2yong.user.util.dummy.RandomUserGenerateUtil.generateRandomUser
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.stereotype.Service
 import kotlin.math.max

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomResponseGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/RandomResponseGenerateUtil.kt
@@ -2,12 +2,27 @@ package com.sbl.sulmun2yong.user.util
 
 import com.sbl.sulmun2yong.survey.domain.Participant
 import com.sbl.sulmun2yong.survey.domain.Survey
-import com.sbl.sulmun2yong.survey.domain.question.ChoiceQuestion
+import com.sbl.sulmun2yong.survey.domain.question.MultipleChoiceQuestion
+import com.sbl.sulmun2yong.survey.domain.question.Question
+import com.sbl.sulmun2yong.survey.domain.question.SingleChoiceQuestion
+import com.sbl.sulmun2yong.survey.domain.question.choice.Choices
 import com.sbl.sulmun2yong.survey.entity.ResponseDocument
 import java.util.UUID
+import kotlin.math.min
 
 object RandomResponseGenerateUtil {
     private val isResponded = Probability(0.6)
+
+    private val randomResponseCountPicker =
+        ProbabilityPicker(
+            mapOf(
+                1 to 0.3,
+                2 to 0.4,
+                3 to 0.2,
+                4 to 0.075,
+                5 to 0.025,
+            ),
+        )
 
     /** 각 참가자별로 설문의 응답을 랜덤하게 생성하여 반환하는 메서드. */
     fun generateSurveyResponseDocuments(
@@ -16,27 +31,50 @@ object RandomResponseGenerateUtil {
     ): List<ResponseDocument> {
         val questions = survey.sections.flatMap { it.questions }
         return questions.flatMap { question ->
-            participants.mapNotNull { participant ->
+            participants.flatMap { participant ->
                 if (question.isRequired || isResponded.isWinning()) {
-                    ResponseDocument(
-                        id = UUID.randomUUID(),
-                        participantId = participant.id,
-                        surveyId = survey.id,
-                        questionId = question.id,
-                        content =
-                            if (question is ChoiceQuestion) {
-                                question.choices
-                                    .getChoiceSet()
-                                    .random()
-                                    .content ?: "잘 모르겠어요"
-                            } else {
-                                "${question.title}에 대한 ${participant.visitorId}의 주관식 답변"
-                            },
-                    )
+                    val contents = getRandomContents(question, participant.visitorId)
+                    contents.map { content ->
+                        ResponseDocument(
+                            id = UUID.randomUUID(),
+                            participantId = participant.id,
+                            surveyId = survey.id,
+                            questionId = question.id,
+                            content = content,
+                        )
+                    }
                 } else {
-                    null
+                    emptyList()
                 }
             }
         }
     }
+
+    private fun getRandomContents(
+        question: Question,
+        visitorId: String,
+    ): List<String> {
+        if (question is SingleChoiceQuestion) {
+            return pickRandomChoiceContent(question.choices, 1)
+        }
+        if (question is MultipleChoiceQuestion) {
+            return pickRandomChoiceContent(question.choices, min(randomResponseCountPicker.pick(), question.choices.getChoiceSet().size))
+        }
+        return listOf(getTextResponseContent(question.title, visitorId))
+    }
+
+    private fun getTextResponseContent(
+        title: String,
+        visitorId: String,
+    ): String = "${title}에 대한 ${visitorId}의 주관식 답변"
+
+    private fun pickRandomChoiceContent(
+        choices: Choices,
+        count: Int,
+    ): List<String> =
+        choices
+            .getChoiceSet()
+            .shuffled()
+            .take(count)
+            .map { it.content ?: "잘 모르겠어요" }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/Probability.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/Probability.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 data class Probability(
     private val chance: Double,

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/ProbabilityPicker.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/ProbabilityPicker.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import kotlin.math.abs
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomParticipantGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomParticipantGenerateUtil.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.survey.domain.Participant
 import java.util.UUID

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomQuestionGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomQuestionGenerateUtil.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.survey.domain.question.Question
 import com.sbl.sulmun2yong.survey.domain.question.QuestionType

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomResponseGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomResponseGenerateUtil.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.survey.domain.Participant
 import com.sbl.sulmun2yong.survey.domain.Survey

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSectionGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSectionGenerateUtil.kt
@@ -1,10 +1,10 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.survey.domain.routing.RoutingStrategy
 import com.sbl.sulmun2yong.survey.domain.section.Section
 import com.sbl.sulmun2yong.survey.domain.section.SectionId
 import com.sbl.sulmun2yong.survey.domain.section.SectionIds
-import com.sbl.sulmun2yong.user.util.RandomQuestionGenerateUtil.generateRandomQuestion
+import com.sbl.sulmun2yong.user.util.dummy.RandomQuestionGenerateUtil.generateRandomQuestion
 
 object RandomSectionGenerateUtil {
     private val randomQuestionCountPicker =

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSurveyGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSurveyGenerateUtil.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.survey.domain.Survey
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomUserGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomUserGenerateUtil.kt
@@ -1,8 +1,9 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.global.config.oauth2.provider.Provider
 import com.sbl.sulmun2yong.user.domain.User
 import com.sbl.sulmun2yong.user.domain.UserRole
+import com.sbl.sulmun2yong.user.util.RandomNicknameGenerator
 import java.util.UUID
 
 object RandomUserGenerateUtil {

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomUtil.kt
@@ -1,4 +1,4 @@
-package com.sbl.sulmun2yong.user.util
+package com.sbl.sulmun2yong.user.util.dummy
 
 import com.sbl.sulmun2yong.global.util.DateUtil
 import java.util.Date


### PR DESCRIPTION
## 📢 설명
- 성능 테스트 진행을 위한 Fingerprint Mocking Server를 사용하는 설문 응답 API 구현([POST] /surveys/response/fake/{survey-id}, RequestBody와 ResponseBody는 기존 설문 응답 API와 동일)
- 개발 서버 CD 파이프라인 동작 시 Fingerprint Mocking Server URL을 주입하도록 수정
- FakeSurveyResponseController, Service, FakeFingerprintApi는 개발 서버에서만 빈이 생성되도록 함(fingerprint.mocking-server-url을 개발 서버에만 주입하는데, 이 값이 없으면 빈 생성 X)
- 다중 선택 질문에 무작위로 여러 선택지에 응답하도록 RandomResponseGenerateUtil 수정

## ✅ 체크 리스트
- [x] application-secrets.yml에 `fingerprint.mocking-server-url: {서버URL}` 추가(해당 값은 노션 환경설정 - github action secrets - FINGERPRINT_MOCKING_SERVER_URL을 확인)
- [x] 테스트용 설문 응답 API 호출 시 아무 visitorId를 넣어도 요청이 성공하는지 확인(단, 이미 참가한 visitorId와 겹치면 안됨)
- [x] `fingerprint.mocking-server-url: {서버URL}` 을 제거한 상태에서 서버 실행 시 Swagger에서 FakeSurveyResponse 부분이 사라지는지 확인
