### PR TITLE
[SBL-209] 설문 목록 조회시 정렬 옵션 추가, 필터 추가, 기타 사항 수정

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/jwt/JwtAuthenticationFilter.kt
@@ -47,7 +47,7 @@ class JwtAuthenticationFilter(
                 response.addCookie(jwtTokenProvider.makeAccessTokenCookie(newAccessToken))
             },
             onFailure = {
-                logger.warn(it.message)
+                // logger.warn(it.message)
             },
         )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -23,10 +23,19 @@ class SurveyAdapter(
         size: Int,
         page: Int,
         sortType: SurveySortType,
-        isAsc: Boolean,
+        isRewardExist: Boolean?,
+        isResultOpen: Boolean?,
     ): Page<Survey> {
-        val pageRequest = PageRequest.of(page, size, getSurveySort(sortType, isAsc))
-        val surveyDocuments = surveyRepository.findByStatusAndIsVisibleTrueAndIsDeletedFalse(SurveyStatus.IN_PROGRESS, pageRequest)
+        val pageRequest = PageRequest.of(page, size, getSurveySort(sortType))
+        val surveyDocuments =
+            surveyRepository.findSurveysWithPagination(
+                size = size,
+                page = page,
+                sortType = sortType,
+                isRewardExist = isRewardExist,
+                isResultOpen = isResultOpen,
+            )
+        println(surveyDocuments.totalPages)
         val surveys = surveyDocuments.content.map { it.toDomain() }
         return PageImpl(surveys, pageRequest, surveyDocuments.totalElements)
     }
@@ -34,18 +43,11 @@ class SurveyAdapter(
     fun getSurvey(surveyId: UUID) =
         surveyRepository.findByIdAndIsDeletedFalse(surveyId).orElseThrow { SurveyNotFoundException() }.toDomain()
 
-    private fun getSurveySort(
-        sortType: SurveySortType,
-        isAsc: Boolean,
-    ) = when (sortType) {
-        SurveySortType.RECENT -> {
-            if (isAsc) {
-                Sort.by("createdAt").ascending()
-            } else {
-                Sort.by("createdAt").descending()
-            }
+    private fun getSurveySort(sortType: SurveySortType) =
+        when (sortType) {
+            SurveySortType.RECENT -> Sort.by("createdAt").ascending()
+            SurveySortType.OLDEST -> Sort.by("createdAt").descending()
         }
-    }
 
     fun save(survey: Survey) {
         val previousSurveyDocument = surveyRepository.findByIdAndIsDeletedFalse(survey.id)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/adapter/SurveyAdapter.kt
@@ -35,7 +35,6 @@ class SurveyAdapter(
                 isRewardExist = isRewardExist,
                 isResultOpen = isResultOpen,
             )
-        println(surveyDocuments.totalPages)
         val surveys = surveyDocuments.content.map { it.toDomain() }
         return PageImpl(surveys, pageRequest, surveyDocuments.totalElements)
     }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyInfoController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyInfoController.kt
@@ -28,10 +28,11 @@ class SurveyInfoController(
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "RECENT") sortType: SurveySortType,
-        @RequestParam(defaultValue = "false") isAsc: Boolean,
+        @RequestParam reward: Boolean?,
+        @RequestParam resultOpen: Boolean?,
     ): ResponseEntity<SurveyListResponse> =
         ResponseEntity.ok(
-            surveyInfoService.getSurveysWithPagination(size, page, sortType, isAsc),
+            surveyInfoService.getSurveysWithPagination(size, page, sortType, reward, resultOpen),
         )
 
     @GetMapping("/info/{survey-id}")

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyInfoApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyInfoApiDoc.kt
@@ -25,7 +25,8 @@ interface SurveyInfoApiDoc {
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(defaultValue = "0") page: Int,
         @RequestParam(defaultValue = "RECENT") sortType: SurveySortType,
-        @RequestParam(defaultValue = "false") isAsc: Boolean,
+        @RequestParam reward: Boolean?,
+        @RequestParam resultOpen: Boolean?,
     ): ResponseEntity<SurveyListResponse>
 
     @Operation(summary = "설문 정보 조회")

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySortType.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/request/SurveySortType.kt
@@ -2,4 +2,5 @@ package com.sbl.sulmun2yong.survey.dto.request
 
 enum class SurveySortType {
     RECENT,
+    OLDEST,
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepository.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepository.kt
@@ -2,7 +2,10 @@ package com.sbl.sulmun2yong.survey.repository
 
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import com.sbl.sulmun2yong.survey.dto.request.MySurveySortType
+import com.sbl.sulmun2yong.survey.dto.request.SurveySortType
 import com.sbl.sulmun2yong.survey.dto.response.MyPageSurveyInfoResponse
+import com.sbl.sulmun2yong.survey.entity.SurveyDocument
+import org.springframework.data.domain.Page
 import java.util.UUID
 
 interface SurveyCustomRepository {
@@ -16,4 +19,12 @@ interface SurveyCustomRepository {
         surveyId: UUID,
         makerId: UUID,
     ): Boolean
+
+    fun findSurveysWithPagination(
+        size: Int,
+        page: Int,
+        sortType: SurveySortType,
+        isRewardExist: Boolean?,
+        isResultOpen: Boolean?,
+    ): Page<SurveyDocument>
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
@@ -2,8 +2,12 @@ package com.sbl.sulmun2yong.survey.repository
 
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
 import com.sbl.sulmun2yong.survey.dto.request.MySurveySortType
+import com.sbl.sulmun2yong.survey.dto.request.SurveySortType
 import com.sbl.sulmun2yong.survey.dto.response.MyPageSurveyInfoResponse
 import com.sbl.sulmun2yong.survey.entity.SurveyDocument
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.core.MongoTemplate
 import org.springframework.data.mongodb.core.aggregation.Aggregation
@@ -63,11 +67,48 @@ class SurveyCustomRepositoryImpl(
         return result.modifiedCount > 0
     }
 
+    override fun findSurveysWithPagination(
+        size: Int,
+        page: Int,
+        sortType: SurveySortType,
+        isRewardExist: Boolean?,
+        isResultOpen: Boolean?,
+    ): Page<SurveyDocument> {
+        val pageRequest = PageRequest.of(page, size, getSurveySort(sortType))
+
+        val query =
+            Query().addCriteria(
+                Criteria
+                    .where("status")
+                    .`is`(SurveyStatus.IN_PROGRESS)
+                    .and("isVisible")
+                    .`is`(true)
+                    .and("isDeleted")
+                    .`is`(false),
+            )
+
+        if (isRewardExist == true) query.addCriteria(Criteria.where("rewardSettingType").ne("NO_REWARD"))
+
+        if (isResultOpen == true) query.addCriteria(Criteria.where("isResultOpen").`is`(true))
+
+        val surveyDocuments = mongoTemplate.find(query.with(pageRequest), SurveyDocument::class.java)
+        val countQuery = Query.of(query).limit(-1).skip(-1)
+        val total = mongoTemplate.count(countQuery, SurveyDocument::class.java)
+
+        return PageImpl(surveyDocuments, pageRequest, total)
+    }
+
     private fun MySurveySortType.toSort() =
         when (this) {
             MySurveySortType.LAST_MODIFIED -> Sort.by(Sort.Direction.DESC, "updatedAt")
             MySurveySortType.OLD_MODIFIED -> Sort.by(Sort.Direction.ASC, "updatedAt")
             MySurveySortType.TITLE_ASC -> Sort.by(Sort.Direction.ASC, "title")
             MySurveySortType.TITLE_DESC -> Sort.by(Sort.Direction.DESC, "title")
+        }
+
+    private fun getSurveySort(sortType: SurveySortType) =
+        when (sortType) {
+            SurveySortType.RECENT -> Sort.by("createdAt").ascending()
+            SurveySortType.OLDEST -> Sort.by("createdAt").descending()
         }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/repository/SurveyCustomRepositoryImpl.kt
@@ -108,7 +108,7 @@ class SurveyCustomRepositoryImpl(
 
     private fun getSurveySort(sortType: SurveySortType) =
         when (sortType) {
-            SurveySortType.RECENT -> Sort.by("createdAt").ascending()
-            SurveySortType.OLDEST -> Sort.by("createdAt").descending()
+            SurveySortType.RECENT -> Sort.by("createdAt").descending()
+            SurveySortType.OLDEST -> Sort.by("createdAt").ascending()
         }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyInfoService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyInfoService.kt
@@ -23,14 +23,16 @@ class SurveyInfoService(
         size: Int,
         page: Int,
         sortType: SurveySortType,
-        isAsc: Boolean,
+        isRewardExist: Boolean?,
+        isResultOpen: Boolean?,
     ): SurveyListResponse {
         val surveys =
             surveyAdapter.findSurveysWithPagination(
                 size = size,
                 page = page,
                 sortType = sortType,
-                isAsc = isAsc,
+                isRewardExist = isRewardExist,
+                isResultOpen = isResultOpen,
             )
         return SurveyListResponse.of(surveys.totalPages, surveys.content)
     }

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomParticipantGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomParticipantGenerateUtil.kt
@@ -4,18 +4,16 @@ import com.sbl.sulmun2yong.survey.domain.Participant
 import java.util.UUID
 
 object RandomParticipantGenerateUtil {
-    // 한 설문 당 평균 113명 참여
+    // 한 설문 당 평균 50명 참여
     private val randomParticipantCountPicker =
         ProbabilityPicker(
             mapOf(
-                0 to 0.075,
+                0 to 0.2,
                 10 to 0.1,
-                30 to 0.2,
+                30 to 0.3,
                 50 to 0.2,
-                100 to 0.25,
+                100 to 0.1,
                 200 to 0.1,
-                500 to 0.05,
-                1000 to 0.025,
             ),
         )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomResponseGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomResponseGenerateUtil.kt
@@ -17,10 +17,9 @@ object RandomResponseGenerateUtil {
         ProbabilityPicker(
             mapOf(
                 1 to 0.3,
-                2 to 0.4,
+                2 to 0.3,
                 3 to 0.2,
-                4 to 0.075,
-                5 to 0.025,
+                4 to 0.2,
             ),
         )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSectionGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSectionGenerateUtil.kt
@@ -11,13 +11,12 @@ object RandomSectionGenerateUtil {
         ProbabilityPicker(
             mapOf(
                 1 to 0.1,
-                2 to 0.1,
+                2 to 0.15,
                 3 to 0.15,
-                4 to 0.15,
+                4 to 0.2,
                 5 to 0.15,
                 6 to 0.15,
                 7 to 0.1,
-                8 to 0.1,
             ),
         )
 

--- a/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSurveyGenerateUtil.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/user/util/dummy/RandomSurveyGenerateUtil.kt
@@ -26,11 +26,10 @@ object RandomSurveyGenerateUtil {
     private val randomSectionCountPicker =
         ProbabilityPicker(
             mapOf(
-                1 to 0.15,
-                2 to 0.25,
-                3 to 0.35,
+                1 to 0.2,
+                2 to 0.3,
+                3 to 0.3,
                 4 to 0.2,
-                5 to 0.05,
             ),
         )
 


### PR DESCRIPTION
## 📢 설명
- 설문 목록 조회 시 통계 보기, 리워드 제공 설문 필터 기능 추가(resultOpen, reward 쿼리 스트링으로 설정 가능, boolean)
- 설문 목록 조회 시 오래된 순 정렬 기능 추가, isAsc 제거
- 리프레시 토큰 오류 발생 시 로그 찍는 코드 제거(리프레시 토큰 없는 비 회원 요청 시 마다 로그가 발생하여 제거함)
- 더미데이터 API 조정(설문 하나당 평균 50명 참여, 질문 평균 10개가 되도록 수정)
