### PR TITLE
[SBL-223] 설문 결과의 raw data를 확인할 수 있는 api 구현

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -23,7 +23,7 @@ enum class ErrorCode(
     INVALID_SECTION_RESPONSE(HttpStatus.BAD_REQUEST, "SV0006", "유효하지 않은 섹션 응답입니다."),
     INVALID_SURVEY(HttpStatus.BAD_REQUEST, "SV0008", "유효하지 않은 설문입니다."),
     INVALID_SURVEY_RESPONSE(HttpStatus.BAD_REQUEST, "SV0009", "유효하지 않은 설문 응답입니다."),
-    INVALID_CHOICE(HttpStatus.BAD_REQUEST, "SV0010", "유효하지 않은 선택지입니다."),
+    CHOICE_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "SV0010", "선택지는 최대 20개까지만 가능합니다."),
     INVALID_REWARD(HttpStatus.BAD_REQUEST, "SV0011", "유효하지 않은 리워드 정보 입니다."),
     INVALID_PARTICIPANT(HttpStatus.BAD_REQUEST, "SV0012", "유효하지 않은 참여자입니다."),
     INVALID_SECTION_IDS(HttpStatus.BAD_REQUEST, "SV0013", "유효하지 않은 섹션 ID입니다."),
@@ -39,6 +39,7 @@ enum class ErrorCode(
     INVALID_PUBLISHED_AT(HttpStatus.BAD_REQUEST, "SV0024", "설문 마감일이 설문 공개일 보다 빠릅니다."),
     INVALID_RESULT_FILTER(HttpStatus.BAD_REQUEST, "SV0025", "필터는 최대 20개 까지만 적용 가능합니다."),
     INVALID_MODIFICATION_TARGET_ID(HttpStatus.BAD_REQUEST, "SV0026", "유효하지 않은 수정 대상 ID입니다."),
+    EMPTY_CHOICE(HttpStatus.BAD_REQUEST, "SV0027", "선택지는 적어도 하나 이상 존재해야 합니다."),
 
     // Drawing (DR)
     INVALID_DRAWING_BOARD(HttpStatus.BAD_REQUEST, "DR0001", "유효하지 않은 추첨 보드입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/SurveyManagementController.kt
@@ -28,6 +28,13 @@ class SurveyManagementController(
         @RequestParam visitorId: String?,
     ) = ResponseEntity.ok(surveyManagementService.getSurveyResult(surveyId, makerId, surveyResultRequest, participantId, visitorId))
 
+    @GetMapping("/raw-result/{survey-id}")
+    override fun getSurveyRawResult(
+        @PathVariable("survey-id") surveyId: UUID,
+        @NullableLoginUser makerId: UUID?,
+        @RequestParam visitorId: String?,
+    ) = ResponseEntity.ok(surveyManagementService.getSurveyRawResult(surveyId, makerId, visitorId))
+
     @GetMapping("/participants/{survey-id}")
     override fun getSurveyParticipants(
         @PathVariable("survey-id") surveyId: UUID,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/controller/doc/SurveyManagementApiDoc.kt
@@ -3,10 +3,12 @@ package com.sbl.sulmun2yong.survey.controller.doc
 import com.sbl.sulmun2yong.global.annotation.NullableLoginUser
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResultRequest
 import com.sbl.sulmun2yong.survey.dto.response.ParticipantsInfoListResponse
+import com.sbl.sulmun2yong.survey.dto.response.SurveyRawResultResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyResultResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,6 +26,14 @@ interface SurveyManagementApiDoc {
         @RequestParam participantId: UUID?,
         @RequestParam visitorId: String?,
     ): ResponseEntity<SurveyResultResponse>
+
+    @Operation(summary = "설문 결과 raw 데이터 조회")
+    @GetMapping("/raw-result/{survey-id}")
+    fun getSurveyRawResult(
+        @PathVariable("survey-id") surveyId: UUID,
+        @NullableLoginUser makerId: UUID?,
+        @RequestParam visitorId: String?,
+    ): ResponseEntity<SurveyRawResultResponse>
 
     @Operation(summary = "참가자 목록")
     @PostMapping("/participants/{survey-id}")

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/Survey.kt
@@ -61,7 +61,7 @@ data class Survey(
                 status = SurveyStatus.NOT_STARTED,
                 finishMessage = DEFAULT_FINISH_MESSAGE,
                 rewardSetting = NoRewardSetting,
-                isVisible = true,
+                isVisible = false,
                 makerId = makerId,
                 sections = listOf(),
                 isResultOpen = false,

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/question/choice/Choices.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/domain/question/choice/Choices.kt
@@ -1,7 +1,8 @@
 package com.sbl.sulmun2yong.survey.domain.question.choice
 
 import com.sbl.sulmun2yong.survey.domain.response.ResponseDetail
-import com.sbl.sulmun2yong.survey.exception.InvalidChoiceException
+import com.sbl.sulmun2yong.survey.exception.ChoiceEmptyException
+import com.sbl.sulmun2yong.survey.exception.ChoiceSizeExceedException
 
 /** 질문에 포함될 선택지 목록 */
 data class Choices(
@@ -14,8 +15,8 @@ data class Choices(
     }
 
     init {
-        if (standardChoices.isEmpty()) throw InvalidChoiceException()
-        if (standardChoices.size > MAX_SIZE) throw InvalidChoiceException()
+        if (standardChoices.isEmpty()) throw ChoiceEmptyException()
+        if (standardChoices.size > MAX_SIZE) throw ChoiceSizeExceedException()
     }
 
     /** 응답이 선택지에 포함되는지 확인 */

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyRawResultResponse.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/dto/response/SurveyRawResultResponse.kt
@@ -1,0 +1,51 @@
+package com.sbl.sulmun2yong.survey.dto.response
+
+import com.sbl.sulmun2yong.survey.domain.Participant
+import com.sbl.sulmun2yong.survey.domain.Survey
+import com.sbl.sulmun2yong.survey.domain.result.SurveyResult
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+data class SurveyRawResultResponse(
+    val rawResults: List<List<String>>,
+) {
+    companion object {
+        fun of(
+            survey: Survey,
+            surveyResult: SurveyResult,
+            participants: List<Participant>,
+        ): SurveyRawResultResponse {
+            val rawResults = mutableListOf<MutableList<String>>()
+
+            val titles = mutableListOf("참가 일시")
+            survey.sections.forEach { section ->
+                section.questions.forEach { question ->
+                    titles.add(question.title)
+                }
+            }
+            rawResults.add(titles)
+
+            participants.forEach { participant ->
+                val dateFormat = SimpleDateFormat("yyyy. M. d a h:mm:ss", Locale.KOREAN)
+                dateFormat.timeZone = TimeZone.getTimeZone("Asia/Seoul")
+                val formattedDate = dateFormat.format(participant.createdAt)
+                val response = mutableListOf(formattedDate)
+                survey.sections
+                    .flatMap { section ->
+                        section.questions.mapNotNull { question ->
+                            surveyResult.findQuestionResult(question.id)?.let { questionResult ->
+                                questionResult.resultDetails
+                                    .find { it.participantId == participant.id }
+                                    ?.contents
+                                    ?.joinToString(",") ?: ""
+                            }
+                        }
+                    }.forEach { response.add(it) }
+                rawResults.add(response)
+            }
+
+            return SurveyRawResultResponse(rawResults)
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/ChoiceEmptyException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/ChoiceEmptyException.kt
@@ -3,4 +3,4 @@ package com.sbl.sulmun2yong.survey.exception
 import com.sbl.sulmun2yong.global.error.BusinessException
 import com.sbl.sulmun2yong.global.error.ErrorCode
 
-class InvalidChoiceException : BusinessException(ErrorCode.INVALID_CHOICE)
+class ChoiceEmptyException : BusinessException(ErrorCode.EMPTY_CHOICE)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/ChoiceSizeExceedException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/exception/ChoiceSizeExceedException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.survey.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class ChoiceSizeExceedException : BusinessException(ErrorCode.CHOICE_SIZE_EXCEED)

--- a/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/survey/service/SurveyManagementService.kt
@@ -7,6 +7,7 @@ import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
 import com.sbl.sulmun2yong.survey.domain.Survey
 import com.sbl.sulmun2yong.survey.dto.request.SurveyResultRequest
 import com.sbl.sulmun2yong.survey.dto.response.ParticipantsInfoListResponse
+import com.sbl.sulmun2yong.survey.dto.response.SurveyRawResultResponse
 import com.sbl.sulmun2yong.survey.dto.response.SurveyResultResponse
 import com.sbl.sulmun2yong.survey.exception.InvalidSurveyAccessException
 import org.springframework.stereotype.Service
@@ -69,6 +70,21 @@ class SurveyManagementService(
                 null
             }
         return ParticipantsInfoListResponse.of(participants, drawingHistories, survey.rewardSetting.targetParticipantCount)
+    }
+
+    fun getSurveyRawResult(
+        surveyId: UUID,
+        makerId: UUID?,
+        visitorId: String?,
+    ): SurveyRawResultResponse {
+        val survey = surveyAdapter.getSurvey(surveyId)
+        // visitorId가 있으면 참가자인지 확인, 없으면 makerId를 확인
+        if (!isValidRequest(survey, makerId, visitorId)) throw InvalidSurveyAccessException()
+
+        val surveyResult = responseAdapter.getSurveyResult(surveyId, null)
+        val participants = participantAdapter.findBySurveyId(surveyId)
+
+        return SurveyRawResultResponse.of(survey, surveyResult, participants)
     }
 
     private fun isValidRequest(

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/SurveyTest.kt
@@ -99,7 +99,7 @@ class SurveyTest {
             assertEquals(SurveyStatus.NOT_STARTED, this.status)
             assertEquals(Survey.DEFAULT_FINISH_MESSAGE, this.finishMessage)
             assertEquals(NoRewardSetting, this.rewardSetting)
-            assertEquals(true, this.isVisible)
+            assertEquals(false, this.isVisible)
             assertEquals(false, this.isResultOpen)
             assertEquals(makerId, this.makerId)
             assertEquals(listOf(), this.sections)

--- a/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/question/ChoicesTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/survey/domain/question/ChoicesTest.kt
@@ -5,7 +5,8 @@ import com.sbl.sulmun2yong.fixture.survey.SurveyConstFactory.CONTENTS
 import com.sbl.sulmun2yong.survey.domain.question.choice.Choice
 import com.sbl.sulmun2yong.survey.domain.question.choice.Choices
 import com.sbl.sulmun2yong.survey.domain.response.ResponseDetail
-import com.sbl.sulmun2yong.survey.exception.InvalidChoiceException
+import com.sbl.sulmun2yong.survey.exception.ChoiceEmptyException
+import com.sbl.sulmun2yong.survey.exception.ChoiceSizeExceedException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
@@ -34,15 +35,15 @@ class ChoicesTest {
 
     @Test
     fun `선택지 목록은 비어있을 수 없다`() {
-        assertThrows<InvalidChoiceException> { Choices(listOf(), true) }
-        assertThrows<InvalidChoiceException> { Choices(listOf(), false) }
+        assertThrows<ChoiceEmptyException> { Choices(listOf(), true) }
+        assertThrows<ChoiceEmptyException> { Choices(listOf(), false) }
     }
 
     @Test
     fun `선택지는 최대 20개 까지만 추가할 수 있다`() {
         val standardChoices = List(Choices.MAX_SIZE + 1) { Choice.Standard(it.toString()) }
-        assertThrows<InvalidChoiceException> { Choices(standardChoices, true) }
-        assertThrows<InvalidChoiceException> { Choices(standardChoices, false) }
+        assertThrows<ChoiceSizeExceedException> { Choices(standardChoices, true) }
+        assertThrows<ChoiceSizeExceedException> { Choices(standardChoices, false) }
     }
 
     @Test


### PR DESCRIPTION
## 📢 설명

- 설문 결과의 raw data를 확인할 수 있는 api 구현
- [GET] `/api/v1/surveys/management/raw-result/{survey-id}`
- ResponseBody
    
    ```json
    {
      "rawResults": [
        [
          "참가 일시",
          "행사 진행의 전반적인 흐름은 어땠나요?",
          "일정의 효율성에 대해 어떻게 평가하시나요?",
          "오리엔테이션에서 새롭게 알게 된 학교 정보는 무엇인가요?",
          "선배들과의 교류에서 얻은 인사이트는 무엇인가요?",
          "행사에서 제공된 정보가 앞으로의 학교생활에 도움이 되었나요?",
          "개선이 필요하다고 느낀 부분은 무엇인가요?"
        ],
        [
          "2024. 10. 29 오전 12:23:23",
          "매우 좋음",
          "매우 효율적임",
          "학사 일정,장학금 정보,ㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁㅁ",
          "",
          "도움이 되었음",
          "ㅇ"
        ],
        [
          "2024. 10. 29 오전 12:31:26",
          "보통",
          "매우 효율적임",
          "동아리 정보,학사 일정",
          "d",
          "도움이 되었음",
          "asd"
        ],
        [
          "2024. 10. 29 오전 12:31:33",
          "보통",
          "매우 효율적임",
          "동아리 정보,학사 일정",
          "d",
          "도움이 되었음",
          "asd"
        ],
        [
          "2024. 10. 29 오전 12:31:36",
          "보통",
          "매우 효율적임",
          "동아리 정보,학사 일정",
          "d",
          "도움이 되었음",
          "asd"
        ]
      ]
    }
    ```
    
- 설문의 선택지 관련 에러에 대한 사유를 구체화
    - 선택지가 20개보다 많은 경우
        
        ```json
        {
          "code": "SV0010",
          "message": "선택지는 최대 20개까지만 가능합니다.",
          "errors": []
        }
        ```
        
    - 선택지가 비어있는 경우
        
        ```json
        {
          "code": "SV0027",
          "message": "선택지는 적어도 하나 이상 존재해야 합니다.",
          "errors": []
        }
        ```
        

## ✅ 체크 리스트 - 프론트엔드 222번 브랜치와 연계하여 진행

- [x]  설문 관리 페이지의 첫 번째 탭의 `엑셀 보기` 버튼 클릭하여 응답에 맞는 xlsx 확장자 파일이 다운로드되었는지 확인
    
   ![image](https://github.com/user-attachments/assets/1898b2ec-4d72-4213-95f6-c6c22a495c41)
    
- [x]  아래의 프롬프트로 초안 생성 API 호출했을 때 에러 이유가 명확히 나오는지 확인
    
    ```json
    1일부터 31일 까지 어떤 날짜가 가장 좋은지 묻는 객관식 질문을 포함한 설문 만들어줘
    ```
    
- [x]  설문 생성 시 isVisible의 기본 값이 isVisible인지 확인