### PR TITLE
HOTFIX: API 응답 형식을 String으로 수정

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/ai/adapter/HealthCheckAdapter.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/ai/adapter/HealthCheckAdapter.kt
@@ -11,7 +11,7 @@ class HealthCheckAdapter(
 ) {
     fun healthCheck() =
         requestToPythonServerTemplate
-            .getForEntity<Unit>(
+            .getForEntity<String>(
                 "/healthcheck",
             ).body ?: throw AIHealthCheckFailException()
 }


### PR DESCRIPTION
## 📢 설명
- API 응답 형식을 String으로 수정
