### PR TITLE
설문이용 v1.3.4 백엔드 배포

### DIFF
--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -14,6 +14,8 @@ enum class ErrorCode(
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "GL0004", "접근 권한이 없습니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "GL0005", "파일은 최대 5mb까지만 업로드할 수 있습니다."),
     UNCLEAN_VISITOR(HttpStatus.FORBIDDEN, "GL0006", "유효하지 않은 visitorId입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.FORBIDDEN, "GL0007", "리소스를 찾을 수 없습니다."),
+    NOT_SUPPORTED_METHOD(HttpStatus.FORBIDDEN, "GL0008", "지원하지 않는 메서드입니다."),
 
     // Survey (SV)
     ALREADY_PARTICIPATED(HttpStatus.BAD_REQUEST, "SV0001", "이미 참여한 설문입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/GlobalExceptionHandler.kt
@@ -4,10 +4,12 @@ import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.AuthenticationException
+import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.multipart.MaxUploadSizeExceededException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -55,5 +57,17 @@ class GlobalExceptionHandler {
     protected fun handleMaxUploadSizeExceededException(e: MaxUploadSizeExceededException): ErrorResponse {
         log.warn(e.message, e)
         return ErrorResponse.of(ErrorCode.FILE_SIZE_EXCEEDED)
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    protected fun handleNoResourceFoundException(e: NoResourceFoundException): ErrorResponse {
+        log.warn(e.message)
+        return ErrorResponse.of(ErrorCode.RESOURCE_NOT_FOUND)
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
+    protected fun handleHttpRequestMethodNotSupportedException(e: HttpRequestMethodNotSupportedException): ErrorResponse {
+        log.warn(e.message)
+        return ErrorResponse.of(ErrorCode.NOT_SUPPORTED_METHOD)
     }
 }


### PR DESCRIPTION
## 📢 설명
- NewRelic(APM)의 1달 로그 용량 제한이 초과되는 문제 발생
- 로그 용량을 줄이기 위해 봇들의 요청으로 발생하는 NoResourceFoundException과 잘못된 요청으로 발생하는 HttpRequestMethodNotSupportedException의 스택트레이스를 로깅하지 않도록 수정