### PR TITLE
[SBL-241] Redis를 활용한 분산락을 통해 추첨 동시성 문제 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,10 @@ dependencies {
 
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.redisson:redisson:3.45.1")
+
+    // AOP
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 }
 
 kotlin {

--- a/src/main/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardService.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardService.kt
@@ -10,6 +10,7 @@ import com.sbl.sulmun2yong.drawing.exception.AlreadyParticipatedDrawingException
 import com.sbl.sulmun2yong.drawing.exception.FinishedDrawingException
 import com.sbl.sulmun2yong.drawing.exception.InvalidDrawingBoardAccessException
 import com.sbl.sulmun2yong.global.data.PhoneNumber
+import com.sbl.sulmun2yong.global.lock.RedissonLock
 import com.sbl.sulmun2yong.survey.adapter.ParticipantAdapter
 import com.sbl.sulmun2yong.survey.adapter.SurveyAdapter
 import com.sbl.sulmun2yong.survey.domain.SurveyStatus
@@ -17,8 +18,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
-// TODO: mongoDB 트랜잭션 테스트 필요
-// TODO: 추후에 패키지 구조를 변경하여 Service가 특정 도메인이 아닌 요청에 종속되도록 하기
 @Service
 class DrawingBoardService(
     private val surveyAdapter: SurveyAdapter,
@@ -28,7 +27,6 @@ class DrawingBoardService(
 ) {
     fun getDrawingBoard(surveyId: UUID): DrawingBoardResponse {
         val surveyStatus = surveyAdapter.getSurvey(surveyId).status
-        // 설문이 시작되지 않았거나, 종료된 경우 접근 불가
         if (surveyStatus == SurveyStatus.NOT_STARTED || surveyStatus == SurveyStatus.CLOSED) {
             throw InvalidDrawingBoardAccessException()
         }
@@ -36,40 +34,42 @@ class DrawingBoardService(
         return DrawingBoardResponse.of(drawingBoard)
     }
 
+    /**
+     * surveyId를 동적으로 조회한 후 락 키를 생성합니다.
+     */
+    @RedissonLock(key = "@drawingLockKeyResolver.getLockKey(#participantId, #selectedNumber)", leaseTime = 10)
     @Transactional
     fun doDrawing(
         participantId: UUID,
         selectedNumber: Int,
         phoneNumber: String,
     ): DrawingResultResponse {
-        // 유효성 검증
-        // 참가했는가
+        // 참가자 및 설문 정보 확인
         val participant = participantAdapter.getByParticipantId(participantId)
         val surveyId = participant.surveyId
 
-        // 추첨 기록이 있는가
+        // 이미 추첨 참여했는지 검증
         val phoneNumberData = PhoneNumber.createWithNonNullable(phoneNumber)
-        val drawingHistory = drawingHistoryAdapter.findBySurveyIdAndParticipantIdOrPhoneNumber(surveyId, participantId, phoneNumberData)
+        val drawingHistory =
+            drawingHistoryAdapter.findBySurveyIdAndParticipantIdOrPhoneNumber(
+                surveyId,
+                participantId,
+                phoneNumberData,
+            )
         if (drawingHistory != null) {
             throw AlreadyParticipatedDrawingException()
         }
-        // 설문이 종료되었는가
+        // 설문 상태 확인
         val survey = surveyAdapter.getSurvey(surveyId)
         if (survey.status == SurveyStatus.CLOSED) {
             throw FinishedDrawingException()
         }
 
-        // 뽑기
-        // 추첨 보드 가져오기
+        // 추첨 처리
         val drawingBoard = drawingBoardAdapter.getBySurveyId(surveyId)
-        // 뽑기
         val drawingResult = drawingBoard.getDrawingResult(selectedNumber)
-
-        // 후속 처리
-        // 보드 업데이트
         val changedDrawingBoard = drawingResult.changedDrawingBoard
-        drawingBoardAdapter.save(drawingResult.changedDrawingBoard)
-        // 추첨 기록 저장
+        drawingBoardAdapter.save(changedDrawingBoard)
         drawingHistoryAdapter.insert(
             DrawingHistory.create(
                 participantId = participantId,
@@ -79,17 +79,14 @@ class DrawingBoardService(
                 ticket = changedDrawingBoard.tickets[selectedNumber],
             ),
         )
-        // 추첨 결과 남은 티켓이 0이됨
+        // 보드에 남은 티켓이 없으면 설문 종료 처리
         if (changedDrawingBoard.tickets.size - changedDrawingBoard.selectedTicketCount <= 0) {
             surveyAdapter.save(survey.finish())
         }
 
-        // dto 반환
-        val drawingResultResponse =
-            when (drawingResult) {
-                is DrawingResult.Winner -> DrawingResultResponse.Winner(drawingResult.rewardName)
-                is DrawingResult.NonWinner -> DrawingResultResponse.NonWinner()
-            }
-        return drawingResultResponse
+        return when (drawingResult) {
+            is DrawingResult.Winner -> DrawingResultResponse.Winner(drawingResult.rewardName)
+            is DrawingResult.NonWinner -> DrawingResultResponse.NonWinner()
+        }
     }
 }

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/config/RedissonConfig.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/config/RedissonConfig.kt
@@ -1,0 +1,27 @@
+package com.sbl.sulmun2yong.global.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig(
+    @Value("\${spring.data.redis.host}")
+    private val redisHost: String,
+    @Value("\${spring.data.redis.port}")
+    private val redisPort: Int,
+    @Value("\${spring.data.redis.password:}")
+    private val redisPassword: String,
+) {
+    @Bean(destroyMethod = "shutdown")
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        val redisAddress = "redis://$redisHost:$redisPort"
+        config.useSingleServer().setAddress(redisAddress)
+        if (redisPassword.isNotEmpty()) config.useSingleServer().setPassword(redisPassword)
+        return Redisson.create(config)
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/error/ErrorCode.kt
@@ -16,6 +16,8 @@ enum class ErrorCode(
     UNCLEAN_VISITOR(HttpStatus.FORBIDDEN, "GL0006", "유효하지 않은 visitorId입니다."),
     RESOURCE_NOT_FOUND(HttpStatus.FORBIDDEN, "GL0007", "리소스를 찾을 수 없습니다."),
     NOT_SUPPORTED_METHOD(HttpStatus.FORBIDDEN, "GL0008", "지원하지 않는 메서드입니다."),
+    INVALID_LOCK_KEY_EXPRESSION(HttpStatus.BAD_REQUEST, "GL0009", "잘못된 Lock Key 표현식 입니다."),
+    TOO_MANY_LOCK_REQUEST(HttpStatus.BAD_REQUEST, "GL0010", "동시 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 
     // Survey (SV)
     ALREADY_PARTICIPATED(HttpStatus.BAD_REQUEST, "SV0001", "이미 참여한 설문입니다."),

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/lock/DrawingLockKeyResolver.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/lock/DrawingLockKeyResolver.kt
@@ -1,0 +1,18 @@
+package com.sbl.sulmun2yong.global.lock
+
+import com.sbl.sulmun2yong.survey.adapter.ParticipantAdapter
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class DrawingLockKeyResolver(
+    private val participantAdapter: ParticipantAdapter,
+) {
+    fun getLockKey(
+        participantId: UUID,
+        selectedNumber: Int,
+    ): String {
+        val surveyId = participantAdapter.getByParticipantId(participantId).surveyId
+        return "drawingLock:$surveyId:$selectedNumber"
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/lock/RedissonLock.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/lock/RedissonLock.kt
@@ -1,0 +1,17 @@
+package com.sbl.sulmun2yong.global.lock
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RedissonLock(
+    /**
+     * SpEL 표현식을 이용하여 동적 락 키 생성
+     * 예: "'drawingLock:' + #participantId + ':' + #selectedNumber"
+     */
+    val key: String,
+    /** 락이 자동 해제되는 시간(초) */
+    val leaseTime: Long = 10,
+    /**
+     * 락 획득 시 대기 시간(초). 0이면 즉시 실패합니다.
+     */
+    val waitTime: Long = 0,
+)

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/lock/RedissonLockAspect.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/lock/RedissonLockAspect.kt
@@ -7,6 +7,8 @@ import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.core.DefaultParameterNameDiscoverer
 import org.springframework.expression.spel.standard.SpelExpressionParser
 import org.springframework.expression.spel.support.StandardEvaluationContext
@@ -17,35 +19,43 @@ import java.util.concurrent.TimeUnit
 @Component
 class RedissonLockAspect(
     private val redissonClient: RedissonClient,
-) {
+) : BeanFactoryAware {
+    private lateinit var beanFactory: BeanFactory
     private val parser = SpelExpressionParser()
-    private val nameDiscoverer = DefaultParameterNameDiscoverer()
+    private val parameterNameDiscoverer = DefaultParameterNameDiscoverer()
 
-    @Around("@annotation(redissonLockAnnotation)")
+    override fun setBeanFactory(beanFactory: BeanFactory) {
+        this.beanFactory = beanFactory
+    }
+
+    @Around("@annotation(redissonLock)")
     fun around(
         joinPoint: ProceedingJoinPoint,
-        redissonLockAnnotation: RedissonLock,
+        redissonLock: RedissonLock,
     ): Any? {
-        // SpEL 평가를 위한 메서드 인자 정보 설정
-        val methodSignature = joinPoint.signature as MethodSignature
-        val parameterNames = nameDiscoverer.getParameterNames(methodSignature.method) ?: emptyArray()
-        val args = joinPoint.args
+        // SpEL 평가 컨텍스트 생성 및 BeanResolver 등록
         val context = StandardEvaluationContext()
-        parameterNames.forEachIndexed { index, name ->
-            context.setVariable(name, args[index])
+        context.setBeanResolver { _: org.springframework.expression.EvaluationContext, beanName: String ->
+            beanFactory.getBean(beanName)
         }
 
-        // SpEL 표현식을 통해 락 키 생성
+        // 메서드 인자 이름 및 값 설정
+        val methodSignature = joinPoint.signature as MethodSignature
+        val parameterNames = parameterNameDiscoverer.getParameterNames(methodSignature.method) ?: emptyArray()
+        parameterNames.forEachIndexed { i, name ->
+            context.setVariable(name, joinPoint.args[i])
+        }
+
+        // SpEL 식을 평가하여 동적 락 키 생성
         val lockKey =
             parser
-                .parseExpression(redissonLockAnnotation.key)
+                .parseExpression(redissonLock.key)
                 .getValue(context, String::class.java)
                 ?: throw InvalidLockKeyExpressionException()
 
+        // Redisson 락 획득
         val lock = redissonClient.getLock(lockKey)
-
-        // 지정한 waitTime 동안 락을 획득 시도 후, leaseTime 동안 유지
-        val acquired = lock.tryLock(redissonLockAnnotation.waitTime, redissonLockAnnotation.leaseTime, TimeUnit.SECONDS)
+        val acquired = lock.tryLock(redissonLock.waitTime, redissonLock.leaseTime, TimeUnit.SECONDS)
         if (!acquired) throw TooManyLockRequestException()
         try {
             return joinPoint.proceed()

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/lock/RedissonLockAspect.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/lock/RedissonLockAspect.kt
@@ -1,0 +1,58 @@
+package com.sbl.sulmun2yong.global.lock
+
+import com.sbl.sulmun2yong.global.lock.exception.InvalidLockKeyExpressionException
+import com.sbl.sulmun2yong.global.lock.exception.TooManyLockRequestException
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RedissonClient
+import org.springframework.core.DefaultParameterNameDiscoverer
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Aspect
+@Component
+class RedissonLockAspect(
+    private val redissonClient: RedissonClient,
+) {
+    private val parser = SpelExpressionParser()
+    private val nameDiscoverer = DefaultParameterNameDiscoverer()
+
+    @Around("@annotation(redissonLockAnnotation)")
+    fun around(
+        joinPoint: ProceedingJoinPoint,
+        redissonLockAnnotation: RedissonLock,
+    ): Any? {
+        // SpEL 평가를 위한 메서드 인자 정보 설정
+        val methodSignature = joinPoint.signature as MethodSignature
+        val parameterNames = nameDiscoverer.getParameterNames(methodSignature.method) ?: emptyArray()
+        val args = joinPoint.args
+        val context = StandardEvaluationContext()
+        parameterNames.forEachIndexed { index, name ->
+            context.setVariable(name, args[index])
+        }
+
+        // SpEL 표현식을 통해 락 키 생성
+        val lockKey =
+            parser
+                .parseExpression(redissonLockAnnotation.key)
+                .getValue(context, String::class.java)
+                ?: throw InvalidLockKeyExpressionException()
+
+        val lock = redissonClient.getLock(lockKey)
+
+        // 지정한 waitTime 동안 락을 획득 시도 후, leaseTime 동안 유지
+        val acquired = lock.tryLock(redissonLockAnnotation.waitTime, redissonLockAnnotation.leaseTime, TimeUnit.SECONDS)
+        if (!acquired) throw TooManyLockRequestException()
+        try {
+            return joinPoint.proceed()
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/lock/exception/InvalidLockKeyExpressionException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/lock/exception/InvalidLockKeyExpressionException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.global.lock.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class InvalidLockKeyExpressionException : BusinessException(ErrorCode.INVALID_LOCK_KEY_EXPRESSION)

--- a/src/main/kotlin/com/sbl/sulmun2yong/global/lock/exception/TooManyLockRequestException.kt
+++ b/src/main/kotlin/com/sbl/sulmun2yong/global/lock/exception/TooManyLockRequestException.kt
@@ -1,0 +1,6 @@
+package com.sbl.sulmun2yong.global.lock.exception
+
+import com.sbl.sulmun2yong.global.error.BusinessException
+import com.sbl.sulmun2yong.global.error.ErrorCode
+
+class TooManyLockRequestException : BusinessException(ErrorCode.TOO_MANY_LOCK_REQUEST)

--- a/src/test/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardServiceConcurrencyTest.kt
+++ b/src/test/kotlin/com/sbl/sulmun2yong/drawing/service/DrawingBoardServiceConcurrencyTest.kt
@@ -1,0 +1,62 @@
+package com.sbl.sulmun2yong.drawing.service
+
+// import org.junit.jupiter.api.Assertions.assertEquals
+// import org.junit.jupiter.api.Test
+// import org.springframework.beans.factory.annotation.Autowired
+// import org.springframework.boot.test.context.SpringBootTest
+// import java.util.UUID
+// import java.util.concurrent.CountDownLatch
+// import java.util.concurrent.Executors
+// import java.util.concurrent.TimeUnit
+//
+// @SpringBootTest
+class DrawingBoardServiceConcurrencyTest(
+    // @Autowired val drawingService: DrawingBoardService,
+)
+// {
+//     @Test
+//     fun `동시 요청 테스트 - 단 하나의 추첨만 성공`() {
+//         // 추첨 번호
+//         val selectedNumber = 5
+//
+//         // 실제 참가자 정보로 대체해야함
+//         val participantInfos =
+//             listOf(
+//                 Pair(UUID.fromString(""), "01000000000"),
+//                 Pair(UUID.fromString(""), "01000000001"),
+//                 Pair(UUID.fromString(""), "01000000002"),
+//                 Pair(UUID.fromString(""), "01000000003"),
+//                 Pair(UUID.fromString(""), "01000000004"),
+//             )
+//
+//         val threadCount = participantInfos.size
+//         val executor = Executors.newFixedThreadPool(threadCount)
+//         val startLatch = CountDownLatch(1)
+//         val results = mutableListOf<String>()
+//
+//         // 각 참가자 정보를 기준으로 동시에 요청을 수행합니다.
+//         participantInfos.forEach { (participantId, phoneNumber) ->
+//             executor.submit {
+//                 startLatch.await()
+//                 try {
+//                     drawingService.doDrawing(participantId, selectedNumber, phoneNumber)
+//                     synchronized(results) {
+//                         results.add("success: ($participantId, $phoneNumber)")
+//                     }
+//                 } catch (e: Exception) {
+//                     synchronized(results) {
+//                         results.add("failure: ($participantId, $phoneNumber): ${e.message}")
+//                     }
+//                 }
+//             }
+//         }
+//
+//         startLatch.countDown()
+//         executor.shutdown()
+//         executor.awaitTermination(10, TimeUnit.SECONDS)
+//
+//         // 중복 참여 체크 로직에 의해 오직 하나의 요청만 정상 처리되어야 합니다.
+//         val successCount = results.count { it.startsWith("success") }
+//         assertEquals(1, successCount, "동시에 한 요청만 성공해야 합니다. 결과: $results")
+//     }
+// }


### PR DESCRIPTION
## 📢 설명
- Redisson Client를 통해 분산락 어노테이션 구현
- 추첨 시 설문 ID와 선택 번호를 통해 락 획득 시도, 10초 동안 획득 실패 시 실패처리, 획득 시 추첨 진행

## ✅ 체크 리스트
- [x] `DrawingBoardServiceConcurrencyTest`의 주석을 해제하고, 올바른 참가자 ID를 넣은 뒤 테스트 코드를 실행하여 1건만 성공하는지 확인
